### PR TITLE
Fix redis not being uncommented if single quotes are used

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -17,7 +17,7 @@ if CABLE_CONFIG_PATH.exist?
   gemfile = File.read(Rails.root.join("Gemfile"))
   if gemfile.include?("redis")
     say "Uncomment redis in Gemfile"
-    uncomment_lines "Gemfile", %(gem "redis")
+    uncomment_lines "Gemfile", %r{gem ['"]redis['"]}
   else
     say "Add redis to Gemfile"
     gem "redis"


### PR DESCRIPTION
Single quotes are required for non-interpolated string literals on some
projects. If the Gemfile has been converted to use single quotes,
including commented lines, then `uncomment_lines` will fail to find it.

(This may be a corner case — RuboCop will not alter the quotes in the commented line, but a developer may have done it manually, perhaps by using their IDE's "convert quotes" functionality.)