### PR TITLE
Fix NoMethodError on Ruby 3.2

### DIFF
--- a/lib/hotwire/livereload/engine.rb
+++ b/lib/hotwire/livereload/engine.rb
@@ -53,7 +53,7 @@ module Hotwire
           force_reload_paths = options.force_reload_paths.map(&:to_s).uniq.join("|")
 
           @listener = Listen.to(*listen_paths) do |modified, added, removed|
-            unless File.exists?(DISABLE_FILE)
+            unless File.exist?(DISABLE_FILE)
               changed = [modified, removed, added].flatten.uniq
               return unless changed.any?
 


### PR DESCRIPTION
Hi there!

Thank you for the gem 😄 Here's a very small (1 char) PR which fixes the face that Ruby has now deprecated the `File.exists?` method. 

See [this commit](https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2)

I replaced it with `File.exist?` which does exactly the same thing.

Thanks!

Nik