### PR TITLE
3 reload modes: hard, soft, css-only. Reload on error pages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea/
+.DS_Store
 /.bundle/
 /doc/
 /log/*.log

--- a/app/assets/javascripts/hotwire-livereload-turbo-stream.js
+++ b/app/assets/javascripts/hotwire-livereload-turbo-stream.js
@@ -77,16 +77,29 @@
 
   // app/javascript/lib/hotwire-livereload-received.js
   var import_debounce = __toModule(require_debounce());
-  var hotwire_livereload_received_default = (0, import_debounce.default)(({ force_reload }) => {
+  var debounced_soft_reload = (0, import_debounce.default)(() => {
+    console.log("[Hotwire::Livereload] Files changed. Reloading..");
+    Turbo.visit(window.location.href, { action: "replace" });
+  }, 300, true);
+  var hotwire_livereload_received_default = ({ mode, changed }) => {
     const onErrorPage = document.title === "Action Controller: Exception caught";
-    if (onErrorPage || force_reload) {
+    if (onErrorPage || mode === "force") {
       console.log("[Hotwire::Livereload] Files changed. Force reloading..");
       document.location.reload();
     } else {
-      console.log("[Hotwire::Livereload] Files changed. Reloading..");
-      Turbo.visit(window.location.href, { action: "replace" });
+      if (mode === "css") {
+        changed.forEach((item, index) => {
+          const stylesheet = document.querySelector(`[data-stylesheet="${item.file}"]`);
+          if (stylesheet) {
+            console.log(`[Hotwire::Livereload] Stylesheet ${item.file} changed. Reloading..`);
+            stylesheet.href = item.path;
+          }
+        });
+      } else {
+        debounced_soft_reload();
+      }
     }
-  }, 300);
+  };
 
   // app/javascript/hotwire-livereload-turbo-stream.js
   (() => {

--- a/app/assets/javascripts/hotwire-livereload-turbo-stream.js
+++ b/app/assets/javascripts/hotwire-livereload-turbo-stream.js
@@ -96,7 +96,12 @@
           }
         });
       } else {
-        debounced_soft_reload();
+        if (window.Turbo) {
+          debounced_soft_reload();
+        } else {
+          console.log("[Hotwire::Livereload] Files changed. Force reloading..");
+          document.location.reload();
+        }
       }
     }
   };
@@ -109,7 +114,7 @@
     window.HotwireLivereload = function({ target }) {
       const element = target.querySelector("template")?.content.getElementById("hotwire-livereload");
       if (element) {
-        hotwire_livereload_received_default({ force_reload: element.dataset.forceReload });
+        hotwire_livereload_received_default({ changed: JSON.parse(element.dataset.changed), mode: element.dataset.mode });
       }
     };
     document.addEventListener("turbo:before-stream-render", window.HotwireLivereload);

--- a/app/assets/javascripts/hotwire-livereload-turbo.js
+++ b/app/assets/javascripts/hotwire-livereload-turbo.js
@@ -1,0 +1,4311 @@
+(() => {
+  var __defProp = Object.defineProperty;
+  var __markAsModule = (target) => __defProp(target, "__esModule", { value: true });
+  var __esm = (fn, res) => function __init() {
+    return fn && (res = (0, fn[Object.keys(fn)[0]])(fn = 0)), res;
+  };
+  var __export = (target, all) => {
+    __markAsModule(target);
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/adapters.js
+  var adapters_default;
+  var init_adapters = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/adapters.js"() {
+      adapters_default = {
+        logger: self.console,
+        WebSocket: self.WebSocket
+      };
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/logger.js
+  var logger_default;
+  var init_logger = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/logger.js"() {
+      init_adapters();
+      logger_default = {
+        log(...messages) {
+          if (this.enabled) {
+            messages.push(Date.now());
+            adapters_default.logger.log("[ActionCable]", ...messages);
+          }
+        }
+      };
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/connection_monitor.js
+  var now, secondsSince, ConnectionMonitor, connection_monitor_default;
+  var init_connection_monitor = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/connection_monitor.js"() {
+      init_logger();
+      now = () => new Date().getTime();
+      secondsSince = (time) => (now() - time) / 1e3;
+      ConnectionMonitor = class {
+        constructor(connection) {
+          this.visibilityDidChange = this.visibilityDidChange.bind(this);
+          this.connection = connection;
+          this.reconnectAttempts = 0;
+        }
+        start() {
+          if (!this.isRunning()) {
+            this.startedAt = now();
+            delete this.stoppedAt;
+            this.startPolling();
+            addEventListener("visibilitychange", this.visibilityDidChange);
+            logger_default.log(`ConnectionMonitor started. stale threshold = ${this.constructor.staleThreshold} s`);
+          }
+        }
+        stop() {
+          if (this.isRunning()) {
+            this.stoppedAt = now();
+            this.stopPolling();
+            removeEventListener("visibilitychange", this.visibilityDidChange);
+            logger_default.log("ConnectionMonitor stopped");
+          }
+        }
+        isRunning() {
+          return this.startedAt && !this.stoppedAt;
+        }
+        recordPing() {
+          this.pingedAt = now();
+        }
+        recordConnect() {
+          this.reconnectAttempts = 0;
+          this.recordPing();
+          delete this.disconnectedAt;
+          logger_default.log("ConnectionMonitor recorded connect");
+        }
+        recordDisconnect() {
+          this.disconnectedAt = now();
+          logger_default.log("ConnectionMonitor recorded disconnect");
+        }
+        startPolling() {
+          this.stopPolling();
+          this.poll();
+        }
+        stopPolling() {
+          clearTimeout(this.pollTimeout);
+        }
+        poll() {
+          this.pollTimeout = setTimeout(() => {
+            this.reconnectIfStale();
+            this.poll();
+          }, this.getPollInterval());
+        }
+        getPollInterval() {
+          const { staleThreshold, reconnectionBackoffRate } = this.constructor;
+          const backoff = Math.pow(1 + reconnectionBackoffRate, Math.min(this.reconnectAttempts, 10));
+          const jitterMax = this.reconnectAttempts === 0 ? 1 : reconnectionBackoffRate;
+          const jitter = jitterMax * Math.random();
+          return staleThreshold * 1e3 * backoff * (1 + jitter);
+        }
+        reconnectIfStale() {
+          if (this.connectionIsStale()) {
+            logger_default.log(`ConnectionMonitor detected stale connection. reconnectAttempts = ${this.reconnectAttempts}, time stale = ${secondsSince(this.refreshedAt)} s, stale threshold = ${this.constructor.staleThreshold} s`);
+            this.reconnectAttempts++;
+            if (this.disconnectedRecently()) {
+              logger_default.log(`ConnectionMonitor skipping reopening recent disconnect. time disconnected = ${secondsSince(this.disconnectedAt)} s`);
+            } else {
+              logger_default.log("ConnectionMonitor reopening");
+              this.connection.reopen();
+            }
+          }
+        }
+        get refreshedAt() {
+          return this.pingedAt ? this.pingedAt : this.startedAt;
+        }
+        connectionIsStale() {
+          return secondsSince(this.refreshedAt) > this.constructor.staleThreshold;
+        }
+        disconnectedRecently() {
+          return this.disconnectedAt && secondsSince(this.disconnectedAt) < this.constructor.staleThreshold;
+        }
+        visibilityDidChange() {
+          if (document.visibilityState === "visible") {
+            setTimeout(() => {
+              if (this.connectionIsStale() || !this.connection.isOpen()) {
+                logger_default.log(`ConnectionMonitor reopening stale connection on visibilitychange. visibilityState = ${document.visibilityState}`);
+                this.connection.reopen();
+              }
+            }, 200);
+          }
+        }
+      };
+      ConnectionMonitor.staleThreshold = 6;
+      ConnectionMonitor.reconnectionBackoffRate = 0.15;
+      connection_monitor_default = ConnectionMonitor;
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/internal.js
+  var internal_default;
+  var init_internal = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/internal.js"() {
+      internal_default = {
+        "message_types": {
+          "welcome": "welcome",
+          "disconnect": "disconnect",
+          "ping": "ping",
+          "confirmation": "confirm_subscription",
+          "rejection": "reject_subscription"
+        },
+        "disconnect_reasons": {
+          "unauthorized": "unauthorized",
+          "invalid_request": "invalid_request",
+          "server_restart": "server_restart"
+        },
+        "default_mount_path": "/cable",
+        "protocols": [
+          "actioncable-v1-json",
+          "actioncable-unsupported"
+        ]
+      };
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/connection.js
+  var message_types, protocols, supportedProtocols, indexOf, Connection, connection_default;
+  var init_connection = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/connection.js"() {
+      init_adapters();
+      init_connection_monitor();
+      init_internal();
+      init_logger();
+      ({ message_types, protocols } = internal_default);
+      supportedProtocols = protocols.slice(0, protocols.length - 1);
+      indexOf = [].indexOf;
+      Connection = class {
+        constructor(consumer2) {
+          this.open = this.open.bind(this);
+          this.consumer = consumer2;
+          this.subscriptions = this.consumer.subscriptions;
+          this.monitor = new connection_monitor_default(this);
+          this.disconnected = true;
+        }
+        send(data) {
+          if (this.isOpen()) {
+            this.webSocket.send(JSON.stringify(data));
+            return true;
+          } else {
+            return false;
+          }
+        }
+        open() {
+          if (this.isActive()) {
+            logger_default.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`);
+            return false;
+          } else {
+            logger_default.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${protocols}`);
+            if (this.webSocket) {
+              this.uninstallEventHandlers();
+            }
+            this.webSocket = new adapters_default.WebSocket(this.consumer.url, protocols);
+            this.installEventHandlers();
+            this.monitor.start();
+            return true;
+          }
+        }
+        close({ allowReconnect } = { allowReconnect: true }) {
+          if (!allowReconnect) {
+            this.monitor.stop();
+          }
+          if (this.isOpen()) {
+            return this.webSocket.close();
+          }
+        }
+        reopen() {
+          logger_default.log(`Reopening WebSocket, current state is ${this.getState()}`);
+          if (this.isActive()) {
+            try {
+              return this.close();
+            } catch (error) {
+              logger_default.log("Failed to reopen WebSocket", error);
+            } finally {
+              logger_default.log(`Reopening WebSocket in ${this.constructor.reopenDelay}ms`);
+              setTimeout(this.open, this.constructor.reopenDelay);
+            }
+          } else {
+            return this.open();
+          }
+        }
+        getProtocol() {
+          if (this.webSocket) {
+            return this.webSocket.protocol;
+          }
+        }
+        isOpen() {
+          return this.isState("open");
+        }
+        isActive() {
+          return this.isState("open", "connecting");
+        }
+        isProtocolSupported() {
+          return indexOf.call(supportedProtocols, this.getProtocol()) >= 0;
+        }
+        isState(...states) {
+          return indexOf.call(states, this.getState()) >= 0;
+        }
+        getState() {
+          if (this.webSocket) {
+            for (let state in adapters_default.WebSocket) {
+              if (adapters_default.WebSocket[state] === this.webSocket.readyState) {
+                return state.toLowerCase();
+              }
+            }
+          }
+          return null;
+        }
+        installEventHandlers() {
+          for (let eventName in this.events) {
+            const handler = this.events[eventName].bind(this);
+            this.webSocket[`on${eventName}`] = handler;
+          }
+        }
+        uninstallEventHandlers() {
+          for (let eventName in this.events) {
+            this.webSocket[`on${eventName}`] = function() {
+            };
+          }
+        }
+      };
+      Connection.reopenDelay = 500;
+      Connection.prototype.events = {
+        message(event) {
+          if (!this.isProtocolSupported()) {
+            return;
+          }
+          const { identifier, message, reason, reconnect, type } = JSON.parse(event.data);
+          switch (type) {
+            case message_types.welcome:
+              this.monitor.recordConnect();
+              return this.subscriptions.reload();
+            case message_types.disconnect:
+              logger_default.log(`Disconnecting. Reason: ${reason}`);
+              return this.close({ allowReconnect: reconnect });
+            case message_types.ping:
+              return this.monitor.recordPing();
+            case message_types.confirmation:
+              this.subscriptions.confirmSubscription(identifier);
+              return this.subscriptions.notify(identifier, "connected");
+            case message_types.rejection:
+              return this.subscriptions.reject(identifier);
+            default:
+              return this.subscriptions.notify(identifier, "received", message);
+          }
+        },
+        open() {
+          logger_default.log(`WebSocket onopen event, using '${this.getProtocol()}' subprotocol`);
+          this.disconnected = false;
+          if (!this.isProtocolSupported()) {
+            logger_default.log("Protocol is unsupported. Stopping monitor and disconnecting.");
+            return this.close({ allowReconnect: false });
+          }
+        },
+        close(event) {
+          logger_default.log("WebSocket onclose event");
+          if (this.disconnected) {
+            return;
+          }
+          this.disconnected = true;
+          this.monitor.recordDisconnect();
+          return this.subscriptions.notifyAll("disconnected", { willAttemptReconnect: this.monitor.isRunning() });
+        },
+        error() {
+          logger_default.log("WebSocket onerror event");
+        }
+      };
+      connection_default = Connection;
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/subscription.js
+  var extend, Subscription;
+  var init_subscription = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/subscription.js"() {
+      extend = function(object, properties) {
+        if (properties != null) {
+          for (let key in properties) {
+            const value = properties[key];
+            object[key] = value;
+          }
+        }
+        return object;
+      };
+      Subscription = class {
+        constructor(consumer2, params = {}, mixin) {
+          this.consumer = consumer2;
+          this.identifier = JSON.stringify(params);
+          extend(this, mixin);
+        }
+        perform(action, data = {}) {
+          data.action = action;
+          return this.send(data);
+        }
+        send(data) {
+          return this.consumer.send({ command: "message", identifier: this.identifier, data: JSON.stringify(data) });
+        }
+        unsubscribe() {
+          return this.consumer.subscriptions.remove(this);
+        }
+      };
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/subscription_guarantor.js
+  var SubscriptionGuarantor, subscription_guarantor_default;
+  var init_subscription_guarantor = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/subscription_guarantor.js"() {
+      init_logger();
+      SubscriptionGuarantor = class {
+        constructor(subscriptions) {
+          this.subscriptions = subscriptions;
+          this.pendingSubscriptions = [];
+        }
+        guarantee(subscription) {
+          if (this.pendingSubscriptions.indexOf(subscription) == -1) {
+            logger_default.log(`SubscriptionGuarantor guaranteeing ${subscription.identifier}`);
+            this.pendingSubscriptions.push(subscription);
+          } else {
+            logger_default.log(`SubscriptionGuarantor already guaranteeing ${subscription.identifier}`);
+          }
+          this.startGuaranteeing();
+        }
+        forget(subscription) {
+          logger_default.log(`SubscriptionGuarantor forgetting ${subscription.identifier}`);
+          this.pendingSubscriptions = this.pendingSubscriptions.filter((s) => s !== subscription);
+        }
+        startGuaranteeing() {
+          this.stopGuaranteeing();
+          this.retrySubscribing();
+        }
+        stopGuaranteeing() {
+          clearTimeout(this.retryTimeout);
+        }
+        retrySubscribing() {
+          this.retryTimeout = setTimeout(() => {
+            if (this.subscriptions && typeof this.subscriptions.subscribe === "function") {
+              this.pendingSubscriptions.map((subscription) => {
+                logger_default.log(`SubscriptionGuarantor resubscribing ${subscription.identifier}`);
+                this.subscriptions.subscribe(subscription);
+              });
+            }
+          }, 500);
+        }
+      };
+      subscription_guarantor_default = SubscriptionGuarantor;
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/subscriptions.js
+  var Subscriptions;
+  var init_subscriptions = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/subscriptions.js"() {
+      init_subscription();
+      init_subscription_guarantor();
+      init_logger();
+      Subscriptions = class {
+        constructor(consumer2) {
+          this.consumer = consumer2;
+          this.guarantor = new subscription_guarantor_default(this);
+          this.subscriptions = [];
+        }
+        create(channelName, mixin) {
+          const channel = channelName;
+          const params = typeof channel === "object" ? channel : { channel };
+          const subscription = new Subscription(this.consumer, params, mixin);
+          return this.add(subscription);
+        }
+        add(subscription) {
+          this.subscriptions.push(subscription);
+          this.consumer.ensureActiveConnection();
+          this.notify(subscription, "initialized");
+          this.subscribe(subscription);
+          return subscription;
+        }
+        remove(subscription) {
+          this.forget(subscription);
+          if (!this.findAll(subscription.identifier).length) {
+            this.sendCommand(subscription, "unsubscribe");
+          }
+          return subscription;
+        }
+        reject(identifier) {
+          return this.findAll(identifier).map((subscription) => {
+            this.forget(subscription);
+            this.notify(subscription, "rejected");
+            return subscription;
+          });
+        }
+        forget(subscription) {
+          this.guarantor.forget(subscription);
+          this.subscriptions = this.subscriptions.filter((s) => s !== subscription);
+          return subscription;
+        }
+        findAll(identifier) {
+          return this.subscriptions.filter((s) => s.identifier === identifier);
+        }
+        reload() {
+          return this.subscriptions.map((subscription) => this.subscribe(subscription));
+        }
+        notifyAll(callbackName, ...args) {
+          return this.subscriptions.map((subscription) => this.notify(subscription, callbackName, ...args));
+        }
+        notify(subscription, callbackName, ...args) {
+          let subscriptions;
+          if (typeof subscription === "string") {
+            subscriptions = this.findAll(subscription);
+          } else {
+            subscriptions = [subscription];
+          }
+          return subscriptions.map((subscription2) => typeof subscription2[callbackName] === "function" ? subscription2[callbackName](...args) : void 0);
+        }
+        subscribe(subscription) {
+          if (this.sendCommand(subscription, "subscribe")) {
+            this.guarantor.guarantee(subscription);
+          }
+        }
+        confirmSubscription(identifier) {
+          logger_default.log(`Subscription confirmed ${identifier}`);
+          this.findAll(identifier).map((subscription) => this.guarantor.forget(subscription));
+        }
+        sendCommand(subscription, command) {
+          const { identifier } = subscription;
+          return this.consumer.send({ command, identifier });
+        }
+      };
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/consumer.js
+  function createWebSocketURL(url) {
+    if (typeof url === "function") {
+      url = url();
+    }
+    if (url && !/^wss?:/i.test(url)) {
+      const a = document.createElement("a");
+      a.href = url;
+      a.href = a.href;
+      a.protocol = a.protocol.replace("http", "ws");
+      return a.href;
+    } else {
+      return url;
+    }
+  }
+  var Consumer;
+  var init_consumer = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/consumer.js"() {
+      init_connection();
+      init_subscriptions();
+      Consumer = class {
+        constructor(url) {
+          this._url = url;
+          this.subscriptions = new Subscriptions(this);
+          this.connection = new connection_default(this);
+        }
+        get url() {
+          return createWebSocketURL(this._url);
+        }
+        send(data) {
+          return this.connection.send(data);
+        }
+        connect() {
+          return this.connection.open();
+        }
+        disconnect() {
+          return this.connection.close({ allowReconnect: false });
+        }
+        ensureActiveConnection() {
+          if (!this.connection.isActive()) {
+            return this.connection.open();
+          }
+        }
+      };
+    }
+  });
+
+  // node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/index.js
+  var src_exports = {};
+  __export(src_exports, {
+    Connection: () => connection_default,
+    ConnectionMonitor: () => connection_monitor_default,
+    Consumer: () => Consumer,
+    INTERNAL: () => internal_default,
+    Subscription: () => Subscription,
+    SubscriptionGuarantor: () => subscription_guarantor_default,
+    Subscriptions: () => Subscriptions,
+    adapters: () => adapters_default,
+    createConsumer: () => createConsumer,
+    createWebSocketURL: () => createWebSocketURL,
+    getConfig: () => getConfig,
+    logger: () => logger_default
+  });
+  function createConsumer(url = getConfig("url") || internal_default.default_mount_path) {
+    return new Consumer(url);
+  }
+  function getConfig(name) {
+    const element = document.head.querySelector(`meta[name='action-cable-${name}']`);
+    if (element) {
+      return element.getAttribute("content");
+    }
+  }
+  var init_src = __esm({
+    "node_modules/@hotwired/turbo-rails/node_modules/@rails/actioncable/src/index.js"() {
+      init_connection();
+      init_connection_monitor();
+      init_consumer();
+      init_internal();
+      init_subscription();
+      init_subscriptions();
+      init_subscription_guarantor();
+      init_adapters();
+      init_logger();
+    }
+  });
+
+  // node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js
+  (function() {
+    if (window.Reflect === void 0 || window.customElements === void 0 || window.customElements.polyfillWrapFlushCallback) {
+      return;
+    }
+    const BuiltInHTMLElement = HTMLElement;
+    const wrapperForTheName = {
+      HTMLElement: function HTMLElement2() {
+        return Reflect.construct(BuiltInHTMLElement, [], this.constructor);
+      }
+    };
+    window.HTMLElement = wrapperForTheName["HTMLElement"];
+    HTMLElement.prototype = BuiltInHTMLElement.prototype;
+    HTMLElement.prototype.constructor = HTMLElement;
+    Object.setPrototypeOf(HTMLElement, BuiltInHTMLElement);
+  })();
+  (function(prototype) {
+    if (typeof prototype.requestSubmit == "function")
+      return;
+    prototype.requestSubmit = function(submitter) {
+      if (submitter) {
+        validateSubmitter(submitter, this);
+        submitter.click();
+      } else {
+        submitter = document.createElement("input");
+        submitter.type = "submit";
+        submitter.hidden = true;
+        this.appendChild(submitter);
+        submitter.click();
+        this.removeChild(submitter);
+      }
+    };
+    function validateSubmitter(submitter, form) {
+      submitter instanceof HTMLElement || raise(TypeError, "parameter 1 is not of type 'HTMLElement'");
+      submitter.type == "submit" || raise(TypeError, "The specified element is not a submit button");
+      submitter.form == form || raise(DOMException, "The specified element is not owned by this form element", "NotFoundError");
+    }
+    function raise(errorConstructor, message, name) {
+      throw new errorConstructor("Failed to execute 'requestSubmit' on 'HTMLFormElement': " + message + ".", name);
+    }
+  })(HTMLFormElement.prototype);
+  var submittersByForm = new WeakMap();
+  function findSubmitterFromClickTarget(target) {
+    const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null;
+    const candidate = element ? element.closest("input, button") : null;
+    return (candidate === null || candidate === void 0 ? void 0 : candidate.type) == "submit" ? candidate : null;
+  }
+  function clickCaptured(event) {
+    const submitter = findSubmitterFromClickTarget(event.target);
+    if (submitter && submitter.form) {
+      submittersByForm.set(submitter.form, submitter);
+    }
+  }
+  (function() {
+    if ("submitter" in Event.prototype)
+      return;
+    let prototype;
+    if ("SubmitEvent" in window && /Apple Computer/.test(navigator.vendor)) {
+      prototype = window.SubmitEvent.prototype;
+    } else if ("SubmitEvent" in window) {
+      return;
+    } else {
+      prototype = window.Event.prototype;
+    }
+    addEventListener("click", clickCaptured, true);
+    Object.defineProperty(prototype, "submitter", {
+      get() {
+        if (this.type == "submit" && this.target instanceof HTMLFormElement) {
+          return submittersByForm.get(this.target);
+        }
+      }
+    });
+  })();
+  var FrameLoadingStyle;
+  (function(FrameLoadingStyle2) {
+    FrameLoadingStyle2["eager"] = "eager";
+    FrameLoadingStyle2["lazy"] = "lazy";
+  })(FrameLoadingStyle || (FrameLoadingStyle = {}));
+  var FrameElement = class extends HTMLElement {
+    constructor() {
+      super();
+      this.loaded = Promise.resolve();
+      this.delegate = new FrameElement.delegateConstructor(this);
+    }
+    static get observedAttributes() {
+      return ["disabled", "complete", "loading", "src"];
+    }
+    connectedCallback() {
+      this.delegate.connect();
+    }
+    disconnectedCallback() {
+      this.delegate.disconnect();
+    }
+    reload() {
+      const { src } = this;
+      this.removeAttribute("complete");
+      this.src = null;
+      this.src = src;
+      return this.loaded;
+    }
+    attributeChangedCallback(name) {
+      if (name == "loading") {
+        this.delegate.loadingStyleChanged();
+      } else if (name == "complete") {
+        this.delegate.completeChanged();
+      } else if (name == "src") {
+        this.delegate.sourceURLChanged();
+      } else {
+        this.delegate.disabledChanged();
+      }
+    }
+    get src() {
+      return this.getAttribute("src");
+    }
+    set src(value) {
+      if (value) {
+        this.setAttribute("src", value);
+      } else {
+        this.removeAttribute("src");
+      }
+    }
+    get loading() {
+      return frameLoadingStyleFromString(this.getAttribute("loading") || "");
+    }
+    set loading(value) {
+      if (value) {
+        this.setAttribute("loading", value);
+      } else {
+        this.removeAttribute("loading");
+      }
+    }
+    get disabled() {
+      return this.hasAttribute("disabled");
+    }
+    set disabled(value) {
+      if (value) {
+        this.setAttribute("disabled", "");
+      } else {
+        this.removeAttribute("disabled");
+      }
+    }
+    get autoscroll() {
+      return this.hasAttribute("autoscroll");
+    }
+    set autoscroll(value) {
+      if (value) {
+        this.setAttribute("autoscroll", "");
+      } else {
+        this.removeAttribute("autoscroll");
+      }
+    }
+    get complete() {
+      return !this.delegate.isLoading;
+    }
+    get isActive() {
+      return this.ownerDocument === document && !this.isPreview;
+    }
+    get isPreview() {
+      var _a, _b;
+      return (_b = (_a = this.ownerDocument) === null || _a === void 0 ? void 0 : _a.documentElement) === null || _b === void 0 ? void 0 : _b.hasAttribute("data-turbo-preview");
+    }
+  };
+  function frameLoadingStyleFromString(style) {
+    switch (style.toLowerCase()) {
+      case "lazy":
+        return FrameLoadingStyle.lazy;
+      default:
+        return FrameLoadingStyle.eager;
+    }
+  }
+  function expandURL(locatable) {
+    return new URL(locatable.toString(), document.baseURI);
+  }
+  function getAnchor(url) {
+    let anchorMatch;
+    if (url.hash) {
+      return url.hash.slice(1);
+    } else if (anchorMatch = url.href.match(/#(.*)$/)) {
+      return anchorMatch[1];
+    }
+  }
+  function getAction(form, submitter) {
+    const action = (submitter === null || submitter === void 0 ? void 0 : submitter.getAttribute("formaction")) || form.getAttribute("action") || form.action;
+    return expandURL(action);
+  }
+  function getExtension(url) {
+    return (getLastPathComponent(url).match(/\.[^.]*$/) || [])[0] || "";
+  }
+  function isHTML(url) {
+    return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/);
+  }
+  function isPrefixedBy(baseURL, url) {
+    const prefix = getPrefix(url);
+    return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix);
+  }
+  function locationIsVisitable(location2, rootLocation) {
+    return isPrefixedBy(location2, rootLocation) && isHTML(location2);
+  }
+  function getRequestURL(url) {
+    const anchor = getAnchor(url);
+    return anchor != null ? url.href.slice(0, -(anchor.length + 1)) : url.href;
+  }
+  function toCacheKey(url) {
+    return getRequestURL(url);
+  }
+  function urlsAreEqual(left, right) {
+    return expandURL(left).href == expandURL(right).href;
+  }
+  function getPathComponents(url) {
+    return url.pathname.split("/").slice(1);
+  }
+  function getLastPathComponent(url) {
+    return getPathComponents(url).slice(-1)[0];
+  }
+  function getPrefix(url) {
+    return addTrailingSlash(url.origin + url.pathname);
+  }
+  function addTrailingSlash(value) {
+    return value.endsWith("/") ? value : value + "/";
+  }
+  var FetchResponse = class {
+    constructor(response) {
+      this.response = response;
+    }
+    get succeeded() {
+      return this.response.ok;
+    }
+    get failed() {
+      return !this.succeeded;
+    }
+    get clientError() {
+      return this.statusCode >= 400 && this.statusCode <= 499;
+    }
+    get serverError() {
+      return this.statusCode >= 500 && this.statusCode <= 599;
+    }
+    get redirected() {
+      return this.response.redirected;
+    }
+    get location() {
+      return expandURL(this.response.url);
+    }
+    get isHTML() {
+      return this.contentType && this.contentType.match(/^(?:text\/([^\s;,]+\b)?html|application\/xhtml\+xml)\b/);
+    }
+    get statusCode() {
+      return this.response.status;
+    }
+    get contentType() {
+      return this.header("Content-Type");
+    }
+    get responseText() {
+      return this.response.clone().text();
+    }
+    get responseHTML() {
+      if (this.isHTML) {
+        return this.response.clone().text();
+      } else {
+        return Promise.resolve(void 0);
+      }
+    }
+    header(name) {
+      return this.response.headers.get(name);
+    }
+  };
+  function isAction(action) {
+    return action == "advance" || action == "replace" || action == "restore";
+  }
+  function activateScriptElement(element) {
+    if (element.getAttribute("data-turbo-eval") == "false") {
+      return element;
+    } else {
+      const createdScriptElement = document.createElement("script");
+      const cspNonce = getMetaContent("csp-nonce");
+      if (cspNonce) {
+        createdScriptElement.nonce = cspNonce;
+      }
+      createdScriptElement.textContent = element.textContent;
+      createdScriptElement.async = false;
+      copyElementAttributes(createdScriptElement, element);
+      return createdScriptElement;
+    }
+  }
+  function copyElementAttributes(destinationElement, sourceElement) {
+    for (const { name, value } of sourceElement.attributes) {
+      destinationElement.setAttribute(name, value);
+    }
+  }
+  function createDocumentFragment(html) {
+    const template = document.createElement("template");
+    template.innerHTML = html;
+    return template.content;
+  }
+  function dispatch(eventName, { target, cancelable, detail } = {}) {
+    const event = new CustomEvent(eventName, {
+      cancelable,
+      bubbles: true,
+      detail
+    });
+    if (target && target.isConnected) {
+      target.dispatchEvent(event);
+    } else {
+      document.documentElement.dispatchEvent(event);
+    }
+    return event;
+  }
+  function nextAnimationFrame() {
+    return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  }
+  function nextEventLoopTick() {
+    return new Promise((resolve) => setTimeout(() => resolve(), 0));
+  }
+  function nextMicrotask() {
+    return Promise.resolve();
+  }
+  function parseHTMLDocument(html = "") {
+    return new DOMParser().parseFromString(html, "text/html");
+  }
+  function unindent(strings, ...values) {
+    const lines = interpolate(strings, values).replace(/^\n/, "").split("\n");
+    const match = lines[0].match(/^\s+/);
+    const indent = match ? match[0].length : 0;
+    return lines.map((line) => line.slice(indent)).join("\n");
+  }
+  function interpolate(strings, values) {
+    return strings.reduce((result, string, i) => {
+      const value = values[i] == void 0 ? "" : values[i];
+      return result + string + value;
+    }, "");
+  }
+  function uuid() {
+    return Array.from({ length: 36 }).map((_, i) => {
+      if (i == 8 || i == 13 || i == 18 || i == 23) {
+        return "-";
+      } else if (i == 14) {
+        return "4";
+      } else if (i == 19) {
+        return (Math.floor(Math.random() * 4) + 8).toString(16);
+      } else {
+        return Math.floor(Math.random() * 15).toString(16);
+      }
+    }).join("");
+  }
+  function getAttribute(attributeName, ...elements) {
+    for (const value of elements.map((element) => element === null || element === void 0 ? void 0 : element.getAttribute(attributeName))) {
+      if (typeof value == "string")
+        return value;
+    }
+    return null;
+  }
+  function hasAttribute(attributeName, ...elements) {
+    return elements.some((element) => element && element.hasAttribute(attributeName));
+  }
+  function markAsBusy(...elements) {
+    for (const element of elements) {
+      if (element.localName == "turbo-frame") {
+        element.setAttribute("busy", "");
+      }
+      element.setAttribute("aria-busy", "true");
+    }
+  }
+  function clearBusyState(...elements) {
+    for (const element of elements) {
+      if (element.localName == "turbo-frame") {
+        element.removeAttribute("busy");
+      }
+      element.removeAttribute("aria-busy");
+    }
+  }
+  function waitForLoad(element, timeoutInMilliseconds = 2e3) {
+    return new Promise((resolve) => {
+      const onComplete = () => {
+        element.removeEventListener("error", onComplete);
+        element.removeEventListener("load", onComplete);
+        resolve();
+      };
+      element.addEventListener("load", onComplete, { once: true });
+      element.addEventListener("error", onComplete, { once: true });
+      setTimeout(resolve, timeoutInMilliseconds);
+    });
+  }
+  function getHistoryMethodForAction(action) {
+    switch (action) {
+      case "replace":
+        return history.replaceState;
+      case "advance":
+      case "restore":
+        return history.pushState;
+    }
+  }
+  function getVisitAction(...elements) {
+    const action = getAttribute("data-turbo-action", ...elements);
+    return isAction(action) ? action : null;
+  }
+  function getMetaElement(name) {
+    return document.querySelector(`meta[name="${name}"]`);
+  }
+  function getMetaContent(name) {
+    const element = getMetaElement(name);
+    return element && element.content;
+  }
+  function setMetaContent(name, content) {
+    let element = getMetaElement(name);
+    if (!element) {
+      element = document.createElement("meta");
+      element.setAttribute("name", name);
+      document.head.appendChild(element);
+    }
+    element.setAttribute("content", content);
+    return element;
+  }
+  var FetchMethod;
+  (function(FetchMethod2) {
+    FetchMethod2[FetchMethod2["get"] = 0] = "get";
+    FetchMethod2[FetchMethod2["post"] = 1] = "post";
+    FetchMethod2[FetchMethod2["put"] = 2] = "put";
+    FetchMethod2[FetchMethod2["patch"] = 3] = "patch";
+    FetchMethod2[FetchMethod2["delete"] = 4] = "delete";
+  })(FetchMethod || (FetchMethod = {}));
+  function fetchMethodFromString(method) {
+    switch (method.toLowerCase()) {
+      case "get":
+        return FetchMethod.get;
+      case "post":
+        return FetchMethod.post;
+      case "put":
+        return FetchMethod.put;
+      case "patch":
+        return FetchMethod.patch;
+      case "delete":
+        return FetchMethod.delete;
+    }
+  }
+  var FetchRequest = class {
+    constructor(delegate, method, location2, body = new URLSearchParams(), target = null) {
+      this.abortController = new AbortController();
+      this.resolveRequestPromise = (_value) => {
+      };
+      this.delegate = delegate;
+      this.method = method;
+      this.headers = this.defaultHeaders;
+      this.body = body;
+      this.url = location2;
+      this.target = target;
+    }
+    get location() {
+      return this.url;
+    }
+    get params() {
+      return this.url.searchParams;
+    }
+    get entries() {
+      return this.body ? Array.from(this.body.entries()) : [];
+    }
+    cancel() {
+      this.abortController.abort();
+    }
+    async perform() {
+      var _a, _b;
+      const { fetchOptions } = this;
+      (_b = (_a = this.delegate).prepareHeadersForRequest) === null || _b === void 0 ? void 0 : _b.call(_a, this.headers, this);
+      await this.allowRequestToBeIntercepted(fetchOptions);
+      try {
+        this.delegate.requestStarted(this);
+        const response = await fetch(this.url.href, fetchOptions);
+        return await this.receive(response);
+      } catch (error) {
+        if (error.name !== "AbortError") {
+          if (this.willDelegateErrorHandling(error)) {
+            this.delegate.requestErrored(this, error);
+          }
+          throw error;
+        }
+      } finally {
+        this.delegate.requestFinished(this);
+      }
+    }
+    async receive(response) {
+      const fetchResponse = new FetchResponse(response);
+      const event = dispatch("turbo:before-fetch-response", {
+        cancelable: true,
+        detail: { fetchResponse },
+        target: this.target
+      });
+      if (event.defaultPrevented) {
+        this.delegate.requestPreventedHandlingResponse(this, fetchResponse);
+      } else if (fetchResponse.succeeded) {
+        this.delegate.requestSucceededWithResponse(this, fetchResponse);
+      } else {
+        this.delegate.requestFailedWithResponse(this, fetchResponse);
+      }
+      return fetchResponse;
+    }
+    get fetchOptions() {
+      var _a;
+      return {
+        method: FetchMethod[this.method].toUpperCase(),
+        credentials: "same-origin",
+        headers: this.headers,
+        redirect: "follow",
+        body: this.isIdempotent ? null : this.body,
+        signal: this.abortSignal,
+        referrer: (_a = this.delegate.referrer) === null || _a === void 0 ? void 0 : _a.href
+      };
+    }
+    get defaultHeaders() {
+      return {
+        Accept: "text/html, application/xhtml+xml"
+      };
+    }
+    get isIdempotent() {
+      return this.method == FetchMethod.get;
+    }
+    get abortSignal() {
+      return this.abortController.signal;
+    }
+    acceptResponseType(mimeType) {
+      this.headers["Accept"] = [mimeType, this.headers["Accept"]].join(", ");
+    }
+    async allowRequestToBeIntercepted(fetchOptions) {
+      const requestInterception = new Promise((resolve) => this.resolveRequestPromise = resolve);
+      const event = dispatch("turbo:before-fetch-request", {
+        cancelable: true,
+        detail: {
+          fetchOptions,
+          url: this.url,
+          resume: this.resolveRequestPromise
+        },
+        target: this.target
+      });
+      if (event.defaultPrevented)
+        await requestInterception;
+    }
+    willDelegateErrorHandling(error) {
+      const event = dispatch("turbo:fetch-request-error", {
+        target: this.target,
+        cancelable: true,
+        detail: { request: this, error }
+      });
+      return !event.defaultPrevented;
+    }
+  };
+  var AppearanceObserver = class {
+    constructor(delegate, element) {
+      this.started = false;
+      this.intersect = (entries) => {
+        const lastEntry = entries.slice(-1)[0];
+        if (lastEntry === null || lastEntry === void 0 ? void 0 : lastEntry.isIntersecting) {
+          this.delegate.elementAppearedInViewport(this.element);
+        }
+      };
+      this.delegate = delegate;
+      this.element = element;
+      this.intersectionObserver = new IntersectionObserver(this.intersect);
+    }
+    start() {
+      if (!this.started) {
+        this.started = true;
+        this.intersectionObserver.observe(this.element);
+      }
+    }
+    stop() {
+      if (this.started) {
+        this.started = false;
+        this.intersectionObserver.unobserve(this.element);
+      }
+    }
+  };
+  var StreamMessage = class {
+    constructor(fragment) {
+      this.fragment = importStreamElements(fragment);
+    }
+    static wrap(message) {
+      if (typeof message == "string") {
+        return new this(createDocumentFragment(message));
+      } else {
+        return message;
+      }
+    }
+  };
+  StreamMessage.contentType = "text/vnd.turbo-stream.html";
+  function importStreamElements(fragment) {
+    for (const element of fragment.querySelectorAll("turbo-stream")) {
+      const streamElement = document.importNode(element, true);
+      for (const inertScriptElement of streamElement.templateElement.content.querySelectorAll("script")) {
+        inertScriptElement.replaceWith(activateScriptElement(inertScriptElement));
+      }
+      element.replaceWith(streamElement);
+    }
+    return fragment;
+  }
+  var FormSubmissionState;
+  (function(FormSubmissionState2) {
+    FormSubmissionState2[FormSubmissionState2["initialized"] = 0] = "initialized";
+    FormSubmissionState2[FormSubmissionState2["requesting"] = 1] = "requesting";
+    FormSubmissionState2[FormSubmissionState2["waiting"] = 2] = "waiting";
+    FormSubmissionState2[FormSubmissionState2["receiving"] = 3] = "receiving";
+    FormSubmissionState2[FormSubmissionState2["stopping"] = 4] = "stopping";
+    FormSubmissionState2[FormSubmissionState2["stopped"] = 5] = "stopped";
+  })(FormSubmissionState || (FormSubmissionState = {}));
+  var FormEnctype;
+  (function(FormEnctype2) {
+    FormEnctype2["urlEncoded"] = "application/x-www-form-urlencoded";
+    FormEnctype2["multipart"] = "multipart/form-data";
+    FormEnctype2["plain"] = "text/plain";
+  })(FormEnctype || (FormEnctype = {}));
+  function formEnctypeFromString(encoding) {
+    switch (encoding.toLowerCase()) {
+      case FormEnctype.multipart:
+        return FormEnctype.multipart;
+      case FormEnctype.plain:
+        return FormEnctype.plain;
+      default:
+        return FormEnctype.urlEncoded;
+    }
+  }
+  var FormSubmission = class {
+    constructor(delegate, formElement, submitter, mustRedirect = false) {
+      this.state = FormSubmissionState.initialized;
+      this.delegate = delegate;
+      this.formElement = formElement;
+      this.submitter = submitter;
+      this.formData = buildFormData(formElement, submitter);
+      this.location = expandURL(this.action);
+      if (this.method == FetchMethod.get) {
+        mergeFormDataEntries(this.location, [...this.body.entries()]);
+      }
+      this.fetchRequest = new FetchRequest(this, this.method, this.location, this.body, this.formElement);
+      this.mustRedirect = mustRedirect;
+    }
+    static confirmMethod(message, _element, _submitter) {
+      return Promise.resolve(confirm(message));
+    }
+    get method() {
+      var _a;
+      const method = ((_a = this.submitter) === null || _a === void 0 ? void 0 : _a.getAttribute("formmethod")) || this.formElement.getAttribute("method") || "";
+      return fetchMethodFromString(method.toLowerCase()) || FetchMethod.get;
+    }
+    get action() {
+      var _a;
+      const formElementAction = typeof this.formElement.action === "string" ? this.formElement.action : null;
+      if ((_a = this.submitter) === null || _a === void 0 ? void 0 : _a.hasAttribute("formaction")) {
+        return this.submitter.getAttribute("formaction") || "";
+      } else {
+        return this.formElement.getAttribute("action") || formElementAction || "";
+      }
+    }
+    get body() {
+      if (this.enctype == FormEnctype.urlEncoded || this.method == FetchMethod.get) {
+        return new URLSearchParams(this.stringFormData);
+      } else {
+        return this.formData;
+      }
+    }
+    get enctype() {
+      var _a;
+      return formEnctypeFromString(((_a = this.submitter) === null || _a === void 0 ? void 0 : _a.getAttribute("formenctype")) || this.formElement.enctype);
+    }
+    get isIdempotent() {
+      return this.fetchRequest.isIdempotent;
+    }
+    get stringFormData() {
+      return [...this.formData].reduce((entries, [name, value]) => {
+        return entries.concat(typeof value == "string" ? [[name, value]] : []);
+      }, []);
+    }
+    async start() {
+      const { initialized, requesting } = FormSubmissionState;
+      const confirmationMessage = getAttribute("data-turbo-confirm", this.submitter, this.formElement);
+      if (typeof confirmationMessage === "string") {
+        const answer = await FormSubmission.confirmMethod(confirmationMessage, this.formElement, this.submitter);
+        if (!answer) {
+          return;
+        }
+      }
+      if (this.state == initialized) {
+        this.state = requesting;
+        return this.fetchRequest.perform();
+      }
+    }
+    stop() {
+      const { stopping, stopped } = FormSubmissionState;
+      if (this.state != stopping && this.state != stopped) {
+        this.state = stopping;
+        this.fetchRequest.cancel();
+        return true;
+      }
+    }
+    prepareHeadersForRequest(headers, request) {
+      if (!request.isIdempotent) {
+        const token = getCookieValue(getMetaContent("csrf-param")) || getMetaContent("csrf-token");
+        if (token) {
+          headers["X-CSRF-Token"] = token;
+        }
+      }
+      if (this.requestAcceptsTurboStreamResponse(request)) {
+        request.acceptResponseType(StreamMessage.contentType);
+      }
+    }
+    requestStarted(_request) {
+      var _a;
+      this.state = FormSubmissionState.waiting;
+      (_a = this.submitter) === null || _a === void 0 ? void 0 : _a.setAttribute("disabled", "");
+      dispatch("turbo:submit-start", {
+        target: this.formElement,
+        detail: { formSubmission: this }
+      });
+      this.delegate.formSubmissionStarted(this);
+    }
+    requestPreventedHandlingResponse(request, response) {
+      this.result = { success: response.succeeded, fetchResponse: response };
+    }
+    requestSucceededWithResponse(request, response) {
+      if (response.clientError || response.serverError) {
+        this.delegate.formSubmissionFailedWithResponse(this, response);
+      } else if (this.requestMustRedirect(request) && responseSucceededWithoutRedirect(response)) {
+        const error = new Error("Form responses must redirect to another location");
+        this.delegate.formSubmissionErrored(this, error);
+      } else {
+        this.state = FormSubmissionState.receiving;
+        this.result = { success: true, fetchResponse: response };
+        this.delegate.formSubmissionSucceededWithResponse(this, response);
+      }
+    }
+    requestFailedWithResponse(request, response) {
+      this.result = { success: false, fetchResponse: response };
+      this.delegate.formSubmissionFailedWithResponse(this, response);
+    }
+    requestErrored(request, error) {
+      this.result = { success: false, error };
+      this.delegate.formSubmissionErrored(this, error);
+    }
+    requestFinished(_request) {
+      var _a;
+      this.state = FormSubmissionState.stopped;
+      (_a = this.submitter) === null || _a === void 0 ? void 0 : _a.removeAttribute("disabled");
+      dispatch("turbo:submit-end", {
+        target: this.formElement,
+        detail: Object.assign({ formSubmission: this }, this.result)
+      });
+      this.delegate.formSubmissionFinished(this);
+    }
+    requestMustRedirect(request) {
+      return !request.isIdempotent && this.mustRedirect;
+    }
+    requestAcceptsTurboStreamResponse(request) {
+      return !request.isIdempotent || hasAttribute("data-turbo-stream", this.submitter, this.formElement);
+    }
+  };
+  function buildFormData(formElement, submitter) {
+    const formData = new FormData(formElement);
+    const name = submitter === null || submitter === void 0 ? void 0 : submitter.getAttribute("name");
+    const value = submitter === null || submitter === void 0 ? void 0 : submitter.getAttribute("value");
+    if (name) {
+      formData.append(name, value || "");
+    }
+    return formData;
+  }
+  function getCookieValue(cookieName) {
+    if (cookieName != null) {
+      const cookies = document.cookie ? document.cookie.split("; ") : [];
+      const cookie = cookies.find((cookie2) => cookie2.startsWith(cookieName));
+      if (cookie) {
+        const value = cookie.split("=").slice(1).join("=");
+        return value ? decodeURIComponent(value) : void 0;
+      }
+    }
+  }
+  function responseSucceededWithoutRedirect(response) {
+    return response.statusCode == 200 && !response.redirected;
+  }
+  function mergeFormDataEntries(url, entries) {
+    const searchParams = new URLSearchParams();
+    for (const [name, value] of entries) {
+      if (value instanceof File)
+        continue;
+      searchParams.append(name, value);
+    }
+    url.search = searchParams.toString();
+    return url;
+  }
+  var Snapshot = class {
+    constructor(element) {
+      this.element = element;
+    }
+    get activeElement() {
+      return this.element.ownerDocument.activeElement;
+    }
+    get children() {
+      return [...this.element.children];
+    }
+    hasAnchor(anchor) {
+      return this.getElementForAnchor(anchor) != null;
+    }
+    getElementForAnchor(anchor) {
+      return anchor ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`) : null;
+    }
+    get isConnected() {
+      return this.element.isConnected;
+    }
+    get firstAutofocusableElement() {
+      const inertDisabledOrHidden = "[inert], :disabled, [hidden], details:not([open]), dialog:not([open])";
+      for (const element of this.element.querySelectorAll("[autofocus]")) {
+        if (element.closest(inertDisabledOrHidden) == null)
+          return element;
+        else
+          continue;
+      }
+      return null;
+    }
+    get permanentElements() {
+      return queryPermanentElementsAll(this.element);
+    }
+    getPermanentElementById(id) {
+      return getPermanentElementById(this.element, id);
+    }
+    getPermanentElementMapForSnapshot(snapshot) {
+      const permanentElementMap = {};
+      for (const currentPermanentElement of this.permanentElements) {
+        const { id } = currentPermanentElement;
+        const newPermanentElement = snapshot.getPermanentElementById(id);
+        if (newPermanentElement) {
+          permanentElementMap[id] = [currentPermanentElement, newPermanentElement];
+        }
+      }
+      return permanentElementMap;
+    }
+  };
+  function getPermanentElementById(node, id) {
+    return node.querySelector(`#${id}[data-turbo-permanent]`);
+  }
+  function queryPermanentElementsAll(node) {
+    return node.querySelectorAll("[id][data-turbo-permanent]");
+  }
+  var FormSubmitObserver = class {
+    constructor(delegate, eventTarget) {
+      this.started = false;
+      this.submitCaptured = () => {
+        this.eventTarget.removeEventListener("submit", this.submitBubbled, false);
+        this.eventTarget.addEventListener("submit", this.submitBubbled, false);
+      };
+      this.submitBubbled = (event) => {
+        if (!event.defaultPrevented) {
+          const form = event.target instanceof HTMLFormElement ? event.target : void 0;
+          const submitter = event.submitter || void 0;
+          if (form && submissionDoesNotDismissDialog(form, submitter) && submissionDoesNotTargetIFrame(form, submitter) && this.delegate.willSubmitForm(form, submitter)) {
+            event.preventDefault();
+            this.delegate.formSubmitted(form, submitter);
+          }
+        }
+      };
+      this.delegate = delegate;
+      this.eventTarget = eventTarget;
+    }
+    start() {
+      if (!this.started) {
+        this.eventTarget.addEventListener("submit", this.submitCaptured, true);
+        this.started = true;
+      }
+    }
+    stop() {
+      if (this.started) {
+        this.eventTarget.removeEventListener("submit", this.submitCaptured, true);
+        this.started = false;
+      }
+    }
+  };
+  function submissionDoesNotDismissDialog(form, submitter) {
+    const method = (submitter === null || submitter === void 0 ? void 0 : submitter.getAttribute("formmethod")) || form.getAttribute("method");
+    return method != "dialog";
+  }
+  function submissionDoesNotTargetIFrame(form, submitter) {
+    const target = (submitter === null || submitter === void 0 ? void 0 : submitter.getAttribute("formtarget")) || form.target;
+    for (const element of document.getElementsByName(target)) {
+      if (element instanceof HTMLIFrameElement)
+        return false;
+    }
+    return true;
+  }
+  var View = class {
+    constructor(delegate, element) {
+      this.resolveRenderPromise = (_value) => {
+      };
+      this.resolveInterceptionPromise = (_value) => {
+      };
+      this.delegate = delegate;
+      this.element = element;
+    }
+    scrollToAnchor(anchor) {
+      const element = this.snapshot.getElementForAnchor(anchor);
+      if (element) {
+        this.scrollToElement(element);
+        this.focusElement(element);
+      } else {
+        this.scrollToPosition({ x: 0, y: 0 });
+      }
+    }
+    scrollToAnchorFromLocation(location2) {
+      this.scrollToAnchor(getAnchor(location2));
+    }
+    scrollToElement(element) {
+      element.scrollIntoView();
+    }
+    focusElement(element) {
+      if (element instanceof HTMLElement) {
+        if (element.hasAttribute("tabindex")) {
+          element.focus();
+        } else {
+          element.setAttribute("tabindex", "-1");
+          element.focus();
+          element.removeAttribute("tabindex");
+        }
+      }
+    }
+    scrollToPosition({ x, y }) {
+      this.scrollRoot.scrollTo(x, y);
+    }
+    scrollToTop() {
+      this.scrollToPosition({ x: 0, y: 0 });
+    }
+    get scrollRoot() {
+      return window;
+    }
+    async render(renderer) {
+      const { isPreview, shouldRender, newSnapshot: snapshot } = renderer;
+      if (shouldRender) {
+        try {
+          this.renderPromise = new Promise((resolve) => this.resolveRenderPromise = resolve);
+          this.renderer = renderer;
+          await this.prepareToRenderSnapshot(renderer);
+          const renderInterception = new Promise((resolve) => this.resolveInterceptionPromise = resolve);
+          const options = { resume: this.resolveInterceptionPromise, render: this.renderer.renderElement };
+          const immediateRender = this.delegate.allowsImmediateRender(snapshot, options);
+          if (!immediateRender)
+            await renderInterception;
+          await this.renderSnapshot(renderer);
+          this.delegate.viewRenderedSnapshot(snapshot, isPreview);
+          this.delegate.preloadOnLoadLinksForView(this.element);
+          this.finishRenderingSnapshot(renderer);
+        } finally {
+          delete this.renderer;
+          this.resolveRenderPromise(void 0);
+          delete this.renderPromise;
+        }
+      } else {
+        this.invalidate(renderer.reloadReason);
+      }
+    }
+    invalidate(reason) {
+      this.delegate.viewInvalidated(reason);
+    }
+    async prepareToRenderSnapshot(renderer) {
+      this.markAsPreview(renderer.isPreview);
+      await renderer.prepareToRender();
+    }
+    markAsPreview(isPreview) {
+      if (isPreview) {
+        this.element.setAttribute("data-turbo-preview", "");
+      } else {
+        this.element.removeAttribute("data-turbo-preview");
+      }
+    }
+    async renderSnapshot(renderer) {
+      await renderer.render();
+    }
+    finishRenderingSnapshot(renderer) {
+      renderer.finishRendering();
+    }
+  };
+  var FrameView = class extends View {
+    invalidate() {
+      this.element.innerHTML = "";
+    }
+    get snapshot() {
+      return new Snapshot(this.element);
+    }
+  };
+  var LinkClickObserver = class {
+    constructor(delegate, eventTarget) {
+      this.started = false;
+      this.clickCaptured = () => {
+        this.eventTarget.removeEventListener("click", this.clickBubbled, false);
+        this.eventTarget.addEventListener("click", this.clickBubbled, false);
+      };
+      this.clickBubbled = (event) => {
+        if (event instanceof MouseEvent && this.clickEventIsSignificant(event)) {
+          const target = event.composedPath && event.composedPath()[0] || event.target;
+          const link = this.findLinkFromClickTarget(target);
+          if (link && doesNotTargetIFrame(link)) {
+            const location2 = this.getLocationForLink(link);
+            if (this.delegate.willFollowLinkToLocation(link, location2, event)) {
+              event.preventDefault();
+              this.delegate.followedLinkToLocation(link, location2);
+            }
+          }
+        }
+      };
+      this.delegate = delegate;
+      this.eventTarget = eventTarget;
+    }
+    start() {
+      if (!this.started) {
+        this.eventTarget.addEventListener("click", this.clickCaptured, true);
+        this.started = true;
+      }
+    }
+    stop() {
+      if (this.started) {
+        this.eventTarget.removeEventListener("click", this.clickCaptured, true);
+        this.started = false;
+      }
+    }
+    clickEventIsSignificant(event) {
+      return !(event.target && event.target.isContentEditable || event.defaultPrevented || event.which > 1 || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey);
+    }
+    findLinkFromClickTarget(target) {
+      if (target instanceof Element) {
+        return target.closest("a[href]:not([target^=_]):not([download])");
+      }
+    }
+    getLocationForLink(link) {
+      return expandURL(link.getAttribute("href") || "");
+    }
+  };
+  function doesNotTargetIFrame(anchor) {
+    for (const element of document.getElementsByName(anchor.target)) {
+      if (element instanceof HTMLIFrameElement)
+        return false;
+    }
+    return true;
+  }
+  var FormLinkClickObserver = class {
+    constructor(delegate, element) {
+      this.delegate = delegate;
+      this.linkClickObserver = new LinkClickObserver(this, element);
+    }
+    start() {
+      this.linkClickObserver.start();
+    }
+    stop() {
+      this.linkClickObserver.stop();
+    }
+    willFollowLinkToLocation(link, location2, originalEvent) {
+      return this.delegate.willSubmitFormLinkToLocation(link, location2, originalEvent) && link.hasAttribute("data-turbo-method");
+    }
+    followedLinkToLocation(link, location2) {
+      const action = location2.href;
+      const form = document.createElement("form");
+      form.setAttribute("data-turbo", "true");
+      form.setAttribute("action", action);
+      form.setAttribute("hidden", "");
+      const method = link.getAttribute("data-turbo-method");
+      if (method)
+        form.setAttribute("method", method);
+      const turboFrame = link.getAttribute("data-turbo-frame");
+      if (turboFrame)
+        form.setAttribute("data-turbo-frame", turboFrame);
+      const turboAction = link.getAttribute("data-turbo-action");
+      if (turboAction)
+        form.setAttribute("data-turbo-action", turboAction);
+      const turboConfirm = link.getAttribute("data-turbo-confirm");
+      if (turboConfirm)
+        form.setAttribute("data-turbo-confirm", turboConfirm);
+      const turboStream = link.hasAttribute("data-turbo-stream");
+      if (turboStream)
+        form.setAttribute("data-turbo-stream", "");
+      this.delegate.submittedFormLinkToLocation(link, location2, form);
+      document.body.appendChild(form);
+      form.addEventListener("turbo:submit-end", () => form.remove(), { once: true });
+      requestAnimationFrame(() => form.requestSubmit());
+    }
+  };
+  var Bardo = class {
+    constructor(delegate, permanentElementMap) {
+      this.delegate = delegate;
+      this.permanentElementMap = permanentElementMap;
+    }
+    static preservingPermanentElements(delegate, permanentElementMap, callback) {
+      const bardo = new this(delegate, permanentElementMap);
+      bardo.enter();
+      callback();
+      bardo.leave();
+    }
+    enter() {
+      for (const id in this.permanentElementMap) {
+        const [currentPermanentElement, newPermanentElement] = this.permanentElementMap[id];
+        this.delegate.enteringBardo(currentPermanentElement, newPermanentElement);
+        this.replaceNewPermanentElementWithPlaceholder(newPermanentElement);
+      }
+    }
+    leave() {
+      for (const id in this.permanentElementMap) {
+        const [currentPermanentElement] = this.permanentElementMap[id];
+        this.replaceCurrentPermanentElementWithClone(currentPermanentElement);
+        this.replacePlaceholderWithPermanentElement(currentPermanentElement);
+        this.delegate.leavingBardo(currentPermanentElement);
+      }
+    }
+    replaceNewPermanentElementWithPlaceholder(permanentElement) {
+      const placeholder = createPlaceholderForPermanentElement(permanentElement);
+      permanentElement.replaceWith(placeholder);
+    }
+    replaceCurrentPermanentElementWithClone(permanentElement) {
+      const clone = permanentElement.cloneNode(true);
+      permanentElement.replaceWith(clone);
+    }
+    replacePlaceholderWithPermanentElement(permanentElement) {
+      const placeholder = this.getPlaceholderById(permanentElement.id);
+      placeholder === null || placeholder === void 0 ? void 0 : placeholder.replaceWith(permanentElement);
+    }
+    getPlaceholderById(id) {
+      return this.placeholders.find((element) => element.content == id);
+    }
+    get placeholders() {
+      return [...document.querySelectorAll("meta[name=turbo-permanent-placeholder][content]")];
+    }
+  };
+  function createPlaceholderForPermanentElement(permanentElement) {
+    const element = document.createElement("meta");
+    element.setAttribute("name", "turbo-permanent-placeholder");
+    element.setAttribute("content", permanentElement.id);
+    return element;
+  }
+  var Renderer = class {
+    constructor(currentSnapshot, newSnapshot, renderElement, isPreview, willRender = true) {
+      this.activeElement = null;
+      this.currentSnapshot = currentSnapshot;
+      this.newSnapshot = newSnapshot;
+      this.isPreview = isPreview;
+      this.willRender = willRender;
+      this.renderElement = renderElement;
+      this.promise = new Promise((resolve, reject) => this.resolvingFunctions = { resolve, reject });
+    }
+    get shouldRender() {
+      return true;
+    }
+    get reloadReason() {
+      return;
+    }
+    prepareToRender() {
+      return;
+    }
+    finishRendering() {
+      if (this.resolvingFunctions) {
+        this.resolvingFunctions.resolve();
+        delete this.resolvingFunctions;
+      }
+    }
+    preservingPermanentElements(callback) {
+      Bardo.preservingPermanentElements(this, this.permanentElementMap, callback);
+    }
+    focusFirstAutofocusableElement() {
+      const element = this.connectedSnapshot.firstAutofocusableElement;
+      if (elementIsFocusable(element)) {
+        element.focus();
+      }
+    }
+    enteringBardo(currentPermanentElement) {
+      if (this.activeElement)
+        return;
+      if (currentPermanentElement.contains(this.currentSnapshot.activeElement)) {
+        this.activeElement = this.currentSnapshot.activeElement;
+      }
+    }
+    leavingBardo(currentPermanentElement) {
+      if (currentPermanentElement.contains(this.activeElement) && this.activeElement instanceof HTMLElement) {
+        this.activeElement.focus();
+        this.activeElement = null;
+      }
+    }
+    get connectedSnapshot() {
+      return this.newSnapshot.isConnected ? this.newSnapshot : this.currentSnapshot;
+    }
+    get currentElement() {
+      return this.currentSnapshot.element;
+    }
+    get newElement() {
+      return this.newSnapshot.element;
+    }
+    get permanentElementMap() {
+      return this.currentSnapshot.getPermanentElementMapForSnapshot(this.newSnapshot);
+    }
+  };
+  function elementIsFocusable(element) {
+    return element && typeof element.focus == "function";
+  }
+  var FrameRenderer = class extends Renderer {
+    constructor(delegate, currentSnapshot, newSnapshot, renderElement, isPreview, willRender = true) {
+      super(currentSnapshot, newSnapshot, renderElement, isPreview, willRender);
+      this.delegate = delegate;
+    }
+    static renderElement(currentElement, newElement) {
+      var _a;
+      const destinationRange = document.createRange();
+      destinationRange.selectNodeContents(currentElement);
+      destinationRange.deleteContents();
+      const frameElement = newElement;
+      const sourceRange = (_a = frameElement.ownerDocument) === null || _a === void 0 ? void 0 : _a.createRange();
+      if (sourceRange) {
+        sourceRange.selectNodeContents(frameElement);
+        currentElement.appendChild(sourceRange.extractContents());
+      }
+    }
+    get shouldRender() {
+      return true;
+    }
+    async render() {
+      await nextAnimationFrame();
+      this.preservingPermanentElements(() => {
+        this.loadFrameElement();
+      });
+      this.scrollFrameIntoView();
+      await nextAnimationFrame();
+      this.focusFirstAutofocusableElement();
+      await nextAnimationFrame();
+      this.activateScriptElements();
+    }
+    loadFrameElement() {
+      this.delegate.willRenderFrame(this.currentElement, this.newElement);
+      this.renderElement(this.currentElement, this.newElement);
+    }
+    scrollFrameIntoView() {
+      if (this.currentElement.autoscroll || this.newElement.autoscroll) {
+        const element = this.currentElement.firstElementChild;
+        const block = readScrollLogicalPosition(this.currentElement.getAttribute("data-autoscroll-block"), "end");
+        const behavior = readScrollBehavior(this.currentElement.getAttribute("data-autoscroll-behavior"), "auto");
+        if (element) {
+          element.scrollIntoView({ block, behavior });
+          return true;
+        }
+      }
+      return false;
+    }
+    activateScriptElements() {
+      for (const inertScriptElement of this.newScriptElements) {
+        const activatedScriptElement = activateScriptElement(inertScriptElement);
+        inertScriptElement.replaceWith(activatedScriptElement);
+      }
+    }
+    get newScriptElements() {
+      return this.currentElement.querySelectorAll("script");
+    }
+  };
+  function readScrollLogicalPosition(value, defaultValue) {
+    if (value == "end" || value == "start" || value == "center" || value == "nearest") {
+      return value;
+    } else {
+      return defaultValue;
+    }
+  }
+  function readScrollBehavior(value, defaultValue) {
+    if (value == "auto" || value == "smooth") {
+      return value;
+    } else {
+      return defaultValue;
+    }
+  }
+  var ProgressBar = class {
+    constructor() {
+      this.hiding = false;
+      this.value = 0;
+      this.visible = false;
+      this.trickle = () => {
+        this.setValue(this.value + Math.random() / 100);
+      };
+      this.stylesheetElement = this.createStylesheetElement();
+      this.progressElement = this.createProgressElement();
+      this.installStylesheetElement();
+      this.setValue(0);
+    }
+    static get defaultCSS() {
+      return unindent`
+      .turbo-progress-bar {
+        position: fixed;
+        display: block;
+        top: 0;
+        left: 0;
+        height: 3px;
+        background: #0076ff;
+        z-index: 2147483647;
+        transition:
+          width ${ProgressBar.animationDuration}ms ease-out,
+          opacity ${ProgressBar.animationDuration / 2}ms ${ProgressBar.animationDuration / 2}ms ease-in;
+        transform: translate3d(0, 0, 0);
+      }
+    `;
+    }
+    show() {
+      if (!this.visible) {
+        this.visible = true;
+        this.installProgressElement();
+        this.startTrickling();
+      }
+    }
+    hide() {
+      if (this.visible && !this.hiding) {
+        this.hiding = true;
+        this.fadeProgressElement(() => {
+          this.uninstallProgressElement();
+          this.stopTrickling();
+          this.visible = false;
+          this.hiding = false;
+        });
+      }
+    }
+    setValue(value) {
+      this.value = value;
+      this.refresh();
+    }
+    installStylesheetElement() {
+      document.head.insertBefore(this.stylesheetElement, document.head.firstChild);
+    }
+    installProgressElement() {
+      this.progressElement.style.width = "0";
+      this.progressElement.style.opacity = "1";
+      document.documentElement.insertBefore(this.progressElement, document.body);
+      this.refresh();
+    }
+    fadeProgressElement(callback) {
+      this.progressElement.style.opacity = "0";
+      setTimeout(callback, ProgressBar.animationDuration * 1.5);
+    }
+    uninstallProgressElement() {
+      if (this.progressElement.parentNode) {
+        document.documentElement.removeChild(this.progressElement);
+      }
+    }
+    startTrickling() {
+      if (!this.trickleInterval) {
+        this.trickleInterval = window.setInterval(this.trickle, ProgressBar.animationDuration);
+      }
+    }
+    stopTrickling() {
+      window.clearInterval(this.trickleInterval);
+      delete this.trickleInterval;
+    }
+    refresh() {
+      requestAnimationFrame(() => {
+        this.progressElement.style.width = `${10 + this.value * 90}%`;
+      });
+    }
+    createStylesheetElement() {
+      const element = document.createElement("style");
+      element.type = "text/css";
+      element.textContent = ProgressBar.defaultCSS;
+      if (this.cspNonce) {
+        element.nonce = this.cspNonce;
+      }
+      return element;
+    }
+    createProgressElement() {
+      const element = document.createElement("div");
+      element.className = "turbo-progress-bar";
+      return element;
+    }
+    get cspNonce() {
+      return getMetaContent("csp-nonce");
+    }
+  };
+  ProgressBar.animationDuration = 300;
+  var HeadSnapshot = class extends Snapshot {
+    constructor() {
+      super(...arguments);
+      this.detailsByOuterHTML = this.children.filter((element) => !elementIsNoscript(element)).map((element) => elementWithoutNonce(element)).reduce((result, element) => {
+        const { outerHTML } = element;
+        const details = outerHTML in result ? result[outerHTML] : {
+          type: elementType(element),
+          tracked: elementIsTracked(element),
+          elements: []
+        };
+        return Object.assign(Object.assign({}, result), { [outerHTML]: Object.assign(Object.assign({}, details), { elements: [...details.elements, element] }) });
+      }, {});
+    }
+    get trackedElementSignature() {
+      return Object.keys(this.detailsByOuterHTML).filter((outerHTML) => this.detailsByOuterHTML[outerHTML].tracked).join("");
+    }
+    getScriptElementsNotInSnapshot(snapshot) {
+      return this.getElementsMatchingTypeNotInSnapshot("script", snapshot);
+    }
+    getStylesheetElementsNotInSnapshot(snapshot) {
+      return this.getElementsMatchingTypeNotInSnapshot("stylesheet", snapshot);
+    }
+    getElementsMatchingTypeNotInSnapshot(matchedType, snapshot) {
+      return Object.keys(this.detailsByOuterHTML).filter((outerHTML) => !(outerHTML in snapshot.detailsByOuterHTML)).map((outerHTML) => this.detailsByOuterHTML[outerHTML]).filter(({ type }) => type == matchedType).map(({ elements: [element] }) => element);
+    }
+    get provisionalElements() {
+      return Object.keys(this.detailsByOuterHTML).reduce((result, outerHTML) => {
+        const { type, tracked, elements } = this.detailsByOuterHTML[outerHTML];
+        if (type == null && !tracked) {
+          return [...result, ...elements];
+        } else if (elements.length > 1) {
+          return [...result, ...elements.slice(1)];
+        } else {
+          return result;
+        }
+      }, []);
+    }
+    getMetaValue(name) {
+      const element = this.findMetaElementByName(name);
+      return element ? element.getAttribute("content") : null;
+    }
+    findMetaElementByName(name) {
+      return Object.keys(this.detailsByOuterHTML).reduce((result, outerHTML) => {
+        const { elements: [element] } = this.detailsByOuterHTML[outerHTML];
+        return elementIsMetaElementWithName(element, name) ? element : result;
+      }, void 0);
+    }
+  };
+  function elementType(element) {
+    if (elementIsScript(element)) {
+      return "script";
+    } else if (elementIsStylesheet(element)) {
+      return "stylesheet";
+    }
+  }
+  function elementIsTracked(element) {
+    return element.getAttribute("data-turbo-track") == "reload";
+  }
+  function elementIsScript(element) {
+    const tagName = element.localName;
+    return tagName == "script";
+  }
+  function elementIsNoscript(element) {
+    const tagName = element.localName;
+    return tagName == "noscript";
+  }
+  function elementIsStylesheet(element) {
+    const tagName = element.localName;
+    return tagName == "style" || tagName == "link" && element.getAttribute("rel") == "stylesheet";
+  }
+  function elementIsMetaElementWithName(element, name) {
+    const tagName = element.localName;
+    return tagName == "meta" && element.getAttribute("name") == name;
+  }
+  function elementWithoutNonce(element) {
+    if (element.hasAttribute("nonce")) {
+      element.setAttribute("nonce", "");
+    }
+    return element;
+  }
+  var PageSnapshot = class extends Snapshot {
+    constructor(element, headSnapshot) {
+      super(element);
+      this.headSnapshot = headSnapshot;
+    }
+    static fromHTMLString(html = "") {
+      return this.fromDocument(parseHTMLDocument(html));
+    }
+    static fromElement(element) {
+      return this.fromDocument(element.ownerDocument);
+    }
+    static fromDocument({ head, body }) {
+      return new this(body, new HeadSnapshot(head));
+    }
+    clone() {
+      const clonedElement = this.element.cloneNode(true);
+      const selectElements = this.element.querySelectorAll("select");
+      const clonedSelectElements = clonedElement.querySelectorAll("select");
+      for (const [index, source] of selectElements.entries()) {
+        const clone = clonedSelectElements[index];
+        for (const option of clone.selectedOptions)
+          option.selected = false;
+        for (const option of source.selectedOptions)
+          clone.options[option.index].selected = true;
+      }
+      for (const clonedPasswordInput of clonedElement.querySelectorAll('input[type="password"]')) {
+        clonedPasswordInput.value = "";
+      }
+      return new PageSnapshot(clonedElement, this.headSnapshot);
+    }
+    get headElement() {
+      return this.headSnapshot.element;
+    }
+    get rootLocation() {
+      var _a;
+      const root = (_a = this.getSetting("root")) !== null && _a !== void 0 ? _a : "/";
+      return expandURL(root);
+    }
+    get cacheControlValue() {
+      return this.getSetting("cache-control");
+    }
+    get isPreviewable() {
+      return this.cacheControlValue != "no-preview";
+    }
+    get isCacheable() {
+      return this.cacheControlValue != "no-cache";
+    }
+    get isVisitable() {
+      return this.getSetting("visit-control") != "reload";
+    }
+    getSetting(name) {
+      return this.headSnapshot.getMetaValue(`turbo-${name}`);
+    }
+  };
+  var TimingMetric;
+  (function(TimingMetric2) {
+    TimingMetric2["visitStart"] = "visitStart";
+    TimingMetric2["requestStart"] = "requestStart";
+    TimingMetric2["requestEnd"] = "requestEnd";
+    TimingMetric2["visitEnd"] = "visitEnd";
+  })(TimingMetric || (TimingMetric = {}));
+  var VisitState;
+  (function(VisitState2) {
+    VisitState2["initialized"] = "initialized";
+    VisitState2["started"] = "started";
+    VisitState2["canceled"] = "canceled";
+    VisitState2["failed"] = "failed";
+    VisitState2["completed"] = "completed";
+  })(VisitState || (VisitState = {}));
+  var defaultOptions = {
+    action: "advance",
+    historyChanged: false,
+    visitCachedSnapshot: () => {
+    },
+    willRender: true,
+    updateHistory: true,
+    shouldCacheSnapshot: true,
+    acceptsStreamResponse: false
+  };
+  var SystemStatusCode;
+  (function(SystemStatusCode2) {
+    SystemStatusCode2[SystemStatusCode2["networkFailure"] = 0] = "networkFailure";
+    SystemStatusCode2[SystemStatusCode2["timeoutFailure"] = -1] = "timeoutFailure";
+    SystemStatusCode2[SystemStatusCode2["contentTypeMismatch"] = -2] = "contentTypeMismatch";
+  })(SystemStatusCode || (SystemStatusCode = {}));
+  var Visit = class {
+    constructor(delegate, location2, restorationIdentifier, options = {}) {
+      this.identifier = uuid();
+      this.timingMetrics = {};
+      this.followedRedirect = false;
+      this.historyChanged = false;
+      this.scrolled = false;
+      this.shouldCacheSnapshot = true;
+      this.acceptsStreamResponse = false;
+      this.snapshotCached = false;
+      this.state = VisitState.initialized;
+      this.delegate = delegate;
+      this.location = location2;
+      this.restorationIdentifier = restorationIdentifier || uuid();
+      const { action, historyChanged, referrer, snapshotHTML, response, visitCachedSnapshot, willRender, updateHistory, shouldCacheSnapshot, acceptsStreamResponse } = Object.assign(Object.assign({}, defaultOptions), options);
+      this.action = action;
+      this.historyChanged = historyChanged;
+      this.referrer = referrer;
+      this.snapshotHTML = snapshotHTML;
+      this.response = response;
+      this.isSamePage = this.delegate.locationWithActionIsSamePage(this.location, this.action);
+      this.visitCachedSnapshot = visitCachedSnapshot;
+      this.willRender = willRender;
+      this.updateHistory = updateHistory;
+      this.scrolled = !willRender;
+      this.shouldCacheSnapshot = shouldCacheSnapshot;
+      this.acceptsStreamResponse = acceptsStreamResponse;
+    }
+    get adapter() {
+      return this.delegate.adapter;
+    }
+    get view() {
+      return this.delegate.view;
+    }
+    get history() {
+      return this.delegate.history;
+    }
+    get restorationData() {
+      return this.history.getRestorationDataForIdentifier(this.restorationIdentifier);
+    }
+    get silent() {
+      return this.isSamePage;
+    }
+    start() {
+      if (this.state == VisitState.initialized) {
+        this.recordTimingMetric(TimingMetric.visitStart);
+        this.state = VisitState.started;
+        this.adapter.visitStarted(this);
+        this.delegate.visitStarted(this);
+      }
+    }
+    cancel() {
+      if (this.state == VisitState.started) {
+        if (this.request) {
+          this.request.cancel();
+        }
+        this.cancelRender();
+        this.state = VisitState.canceled;
+      }
+    }
+    complete() {
+      if (this.state == VisitState.started) {
+        this.recordTimingMetric(TimingMetric.visitEnd);
+        this.state = VisitState.completed;
+        this.followRedirect();
+        if (!this.followedRedirect) {
+          this.adapter.visitCompleted(this);
+          this.delegate.visitCompleted(this);
+        }
+      }
+    }
+    fail() {
+      if (this.state == VisitState.started) {
+        this.state = VisitState.failed;
+        this.adapter.visitFailed(this);
+      }
+    }
+    changeHistory() {
+      var _a;
+      if (!this.historyChanged && this.updateHistory) {
+        const actionForHistory = this.location.href === ((_a = this.referrer) === null || _a === void 0 ? void 0 : _a.href) ? "replace" : this.action;
+        const method = getHistoryMethodForAction(actionForHistory);
+        this.history.update(method, this.location, this.restorationIdentifier);
+        this.historyChanged = true;
+      }
+    }
+    issueRequest() {
+      if (this.hasPreloadedResponse()) {
+        this.simulateRequest();
+      } else if (this.shouldIssueRequest() && !this.request) {
+        this.request = new FetchRequest(this, FetchMethod.get, this.location);
+        this.request.perform();
+      }
+    }
+    simulateRequest() {
+      if (this.response) {
+        this.startRequest();
+        this.recordResponse();
+        this.finishRequest();
+      }
+    }
+    startRequest() {
+      this.recordTimingMetric(TimingMetric.requestStart);
+      this.adapter.visitRequestStarted(this);
+    }
+    recordResponse(response = this.response) {
+      this.response = response;
+      if (response) {
+        const { statusCode } = response;
+        if (isSuccessful(statusCode)) {
+          this.adapter.visitRequestCompleted(this);
+        } else {
+          this.adapter.visitRequestFailedWithStatusCode(this, statusCode);
+        }
+      }
+    }
+    finishRequest() {
+      this.recordTimingMetric(TimingMetric.requestEnd);
+      this.adapter.visitRequestFinished(this);
+    }
+    loadResponse() {
+      if (this.response) {
+        const { statusCode, responseHTML } = this.response;
+        this.render(async () => {
+          if (this.shouldCacheSnapshot)
+            this.cacheSnapshot();
+          if (this.view.renderPromise)
+            await this.view.renderPromise;
+          if (isSuccessful(statusCode) && responseHTML != null) {
+            await this.view.renderPage(PageSnapshot.fromHTMLString(responseHTML), false, this.willRender, this);
+            this.performScroll();
+            this.adapter.visitRendered(this);
+            this.complete();
+          } else {
+            await this.view.renderError(PageSnapshot.fromHTMLString(responseHTML), this);
+            this.adapter.visitRendered(this);
+            this.fail();
+          }
+        });
+      }
+    }
+    getCachedSnapshot() {
+      const snapshot = this.view.getCachedSnapshotForLocation(this.location) || this.getPreloadedSnapshot();
+      if (snapshot && (!getAnchor(this.location) || snapshot.hasAnchor(getAnchor(this.location)))) {
+        if (this.action == "restore" || snapshot.isPreviewable) {
+          return snapshot;
+        }
+      }
+    }
+    getPreloadedSnapshot() {
+      if (this.snapshotHTML) {
+        return PageSnapshot.fromHTMLString(this.snapshotHTML);
+      }
+    }
+    hasCachedSnapshot() {
+      return this.getCachedSnapshot() != null;
+    }
+    loadCachedSnapshot() {
+      const snapshot = this.getCachedSnapshot();
+      if (snapshot) {
+        const isPreview = this.shouldIssueRequest();
+        this.render(async () => {
+          this.cacheSnapshot();
+          if (this.isSamePage) {
+            this.adapter.visitRendered(this);
+          } else {
+            if (this.view.renderPromise)
+              await this.view.renderPromise;
+            await this.view.renderPage(snapshot, isPreview, this.willRender, this);
+            this.performScroll();
+            this.adapter.visitRendered(this);
+            if (!isPreview) {
+              this.complete();
+            }
+          }
+        });
+      }
+    }
+    followRedirect() {
+      var _a;
+      if (this.redirectedToLocation && !this.followedRedirect && ((_a = this.response) === null || _a === void 0 ? void 0 : _a.redirected)) {
+        this.adapter.visitProposedToLocation(this.redirectedToLocation, {
+          action: "replace",
+          response: this.response
+        });
+        this.followedRedirect = true;
+      }
+    }
+    goToSamePageAnchor() {
+      if (this.isSamePage) {
+        this.render(async () => {
+          this.cacheSnapshot();
+          this.performScroll();
+          this.adapter.visitRendered(this);
+        });
+      }
+    }
+    prepareHeadersForRequest(headers, request) {
+      if (this.acceptsStreamResponse) {
+        request.acceptResponseType(StreamMessage.contentType);
+      }
+    }
+    requestStarted() {
+      this.startRequest();
+    }
+    requestPreventedHandlingResponse(_request, _response) {
+    }
+    async requestSucceededWithResponse(request, response) {
+      const responseHTML = await response.responseHTML;
+      const { redirected, statusCode } = response;
+      if (responseHTML == void 0) {
+        this.recordResponse({
+          statusCode: SystemStatusCode.contentTypeMismatch,
+          redirected
+        });
+      } else {
+        this.redirectedToLocation = response.redirected ? response.location : void 0;
+        this.recordResponse({ statusCode, responseHTML, redirected });
+      }
+    }
+    async requestFailedWithResponse(request, response) {
+      const responseHTML = await response.responseHTML;
+      const { redirected, statusCode } = response;
+      if (responseHTML == void 0) {
+        this.recordResponse({
+          statusCode: SystemStatusCode.contentTypeMismatch,
+          redirected
+        });
+      } else {
+        this.recordResponse({ statusCode, responseHTML, redirected });
+      }
+    }
+    requestErrored(_request, _error) {
+      this.recordResponse({
+        statusCode: SystemStatusCode.networkFailure,
+        redirected: false
+      });
+    }
+    requestFinished() {
+      this.finishRequest();
+    }
+    performScroll() {
+      if (!this.scrolled && !this.view.forceReloaded) {
+        if (this.action == "restore") {
+          this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop();
+        } else {
+          this.scrollToAnchor() || this.view.scrollToTop();
+        }
+        if (this.isSamePage) {
+          this.delegate.visitScrolledToSamePageLocation(this.view.lastRenderedLocation, this.location);
+        }
+        this.scrolled = true;
+      }
+    }
+    scrollToRestoredPosition() {
+      const { scrollPosition } = this.restorationData;
+      if (scrollPosition) {
+        this.view.scrollToPosition(scrollPosition);
+        return true;
+      }
+    }
+    scrollToAnchor() {
+      const anchor = getAnchor(this.location);
+      if (anchor != null) {
+        this.view.scrollToAnchor(anchor);
+        return true;
+      }
+    }
+    recordTimingMetric(metric) {
+      this.timingMetrics[metric] = new Date().getTime();
+    }
+    getTimingMetrics() {
+      return Object.assign({}, this.timingMetrics);
+    }
+    getHistoryMethodForAction(action) {
+      switch (action) {
+        case "replace":
+          return history.replaceState;
+        case "advance":
+        case "restore":
+          return history.pushState;
+      }
+    }
+    hasPreloadedResponse() {
+      return typeof this.response == "object";
+    }
+    shouldIssueRequest() {
+      if (this.isSamePage) {
+        return false;
+      } else if (this.action == "restore") {
+        return !this.hasCachedSnapshot();
+      } else {
+        return this.willRender;
+      }
+    }
+    cacheSnapshot() {
+      if (!this.snapshotCached) {
+        this.view.cacheSnapshot().then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot));
+        this.snapshotCached = true;
+      }
+    }
+    async render(callback) {
+      this.cancelRender();
+      await new Promise((resolve) => {
+        this.frame = requestAnimationFrame(() => resolve());
+      });
+      await callback();
+      delete this.frame;
+    }
+    cancelRender() {
+      if (this.frame) {
+        cancelAnimationFrame(this.frame);
+        delete this.frame;
+      }
+    }
+  };
+  function isSuccessful(statusCode) {
+    return statusCode >= 200 && statusCode < 300;
+  }
+  var BrowserAdapter = class {
+    constructor(session2) {
+      this.progressBar = new ProgressBar();
+      this.showProgressBar = () => {
+        this.progressBar.show();
+      };
+      this.session = session2;
+    }
+    visitProposedToLocation(location2, options) {
+      this.navigator.startVisit(location2, (options === null || options === void 0 ? void 0 : options.restorationIdentifier) || uuid(), options);
+    }
+    visitStarted(visit2) {
+      this.location = visit2.location;
+      visit2.loadCachedSnapshot();
+      visit2.issueRequest();
+      visit2.goToSamePageAnchor();
+    }
+    visitRequestStarted(visit2) {
+      this.progressBar.setValue(0);
+      if (visit2.hasCachedSnapshot() || visit2.action != "restore") {
+        this.showVisitProgressBarAfterDelay();
+      } else {
+        this.showProgressBar();
+      }
+    }
+    visitRequestCompleted(visit2) {
+      visit2.loadResponse();
+    }
+    visitRequestFailedWithStatusCode(visit2, statusCode) {
+      switch (statusCode) {
+        case SystemStatusCode.networkFailure:
+        case SystemStatusCode.timeoutFailure:
+        case SystemStatusCode.contentTypeMismatch:
+          return this.reload({
+            reason: "request_failed",
+            context: {
+              statusCode
+            }
+          });
+        default:
+          return visit2.loadResponse();
+      }
+    }
+    visitRequestFinished(_visit) {
+      this.progressBar.setValue(1);
+      this.hideVisitProgressBar();
+    }
+    visitCompleted(_visit) {
+    }
+    pageInvalidated(reason) {
+      this.reload(reason);
+    }
+    visitFailed(_visit) {
+    }
+    visitRendered(_visit) {
+    }
+    formSubmissionStarted(_formSubmission) {
+      this.progressBar.setValue(0);
+      this.showFormProgressBarAfterDelay();
+    }
+    formSubmissionFinished(_formSubmission) {
+      this.progressBar.setValue(1);
+      this.hideFormProgressBar();
+    }
+    showVisitProgressBarAfterDelay() {
+      this.visitProgressBarTimeout = window.setTimeout(this.showProgressBar, this.session.progressBarDelay);
+    }
+    hideVisitProgressBar() {
+      this.progressBar.hide();
+      if (this.visitProgressBarTimeout != null) {
+        window.clearTimeout(this.visitProgressBarTimeout);
+        delete this.visitProgressBarTimeout;
+      }
+    }
+    showFormProgressBarAfterDelay() {
+      if (this.formProgressBarTimeout == null) {
+        this.formProgressBarTimeout = window.setTimeout(this.showProgressBar, this.session.progressBarDelay);
+      }
+    }
+    hideFormProgressBar() {
+      this.progressBar.hide();
+      if (this.formProgressBarTimeout != null) {
+        window.clearTimeout(this.formProgressBarTimeout);
+        delete this.formProgressBarTimeout;
+      }
+    }
+    reload(reason) {
+      dispatch("turbo:reload", { detail: reason });
+      if (!this.location)
+        return;
+      window.location.href = this.location.toString();
+    }
+    get navigator() {
+      return this.session.navigator;
+    }
+  };
+  var CacheObserver = class {
+    constructor() {
+      this.started = false;
+      this.removeStaleElements = (_event) => {
+        const staleElements = [...document.querySelectorAll('[data-turbo-cache="false"]')];
+        for (const element of staleElements) {
+          element.remove();
+        }
+      };
+    }
+    start() {
+      if (!this.started) {
+        this.started = true;
+        addEventListener("turbo:before-cache", this.removeStaleElements, false);
+      }
+    }
+    stop() {
+      if (this.started) {
+        this.started = false;
+        removeEventListener("turbo:before-cache", this.removeStaleElements, false);
+      }
+    }
+  };
+  var FrameRedirector = class {
+    constructor(session2, element) {
+      this.session = session2;
+      this.element = element;
+      this.linkClickObserver = new LinkClickObserver(this, element);
+      this.formSubmitObserver = new FormSubmitObserver(this, element);
+    }
+    start() {
+      this.linkClickObserver.start();
+      this.formSubmitObserver.start();
+    }
+    stop() {
+      this.linkClickObserver.stop();
+      this.formSubmitObserver.stop();
+    }
+    willFollowLinkToLocation(element, location2, event) {
+      return this.shouldRedirect(element) && this.frameAllowsVisitingLocation(element, location2, event);
+    }
+    followedLinkToLocation(element, url) {
+      const frame = this.findFrameElement(element);
+      if (frame) {
+        frame.delegate.followedLinkToLocation(element, url);
+      }
+    }
+    willSubmitForm(element, submitter) {
+      return element.closest("turbo-frame") == null && this.shouldSubmit(element, submitter) && this.shouldRedirect(element, submitter);
+    }
+    formSubmitted(element, submitter) {
+      const frame = this.findFrameElement(element, submitter);
+      if (frame) {
+        frame.delegate.formSubmitted(element, submitter);
+      }
+    }
+    frameAllowsVisitingLocation(target, { href: url }, originalEvent) {
+      const event = dispatch("turbo:click", {
+        target,
+        detail: { url, originalEvent },
+        cancelable: true
+      });
+      return !event.defaultPrevented;
+    }
+    shouldSubmit(form, submitter) {
+      var _a;
+      const action = getAction(form, submitter);
+      const meta = this.element.ownerDocument.querySelector(`meta[name="turbo-root"]`);
+      const rootLocation = expandURL((_a = meta === null || meta === void 0 ? void 0 : meta.content) !== null && _a !== void 0 ? _a : "/");
+      return this.shouldRedirect(form, submitter) && locationIsVisitable(action, rootLocation);
+    }
+    shouldRedirect(element, submitter) {
+      const isNavigatable = element instanceof HTMLFormElement ? this.session.submissionIsNavigatable(element, submitter) : this.session.elementIsNavigatable(element);
+      if (isNavigatable) {
+        const frame = this.findFrameElement(element, submitter);
+        return frame ? frame != element.closest("turbo-frame") : false;
+      } else {
+        return false;
+      }
+    }
+    findFrameElement(element, submitter) {
+      const id = (submitter === null || submitter === void 0 ? void 0 : submitter.getAttribute("data-turbo-frame")) || element.getAttribute("data-turbo-frame");
+      if (id && id != "_top") {
+        const frame = this.element.querySelector(`#${id}:not([disabled])`);
+        if (frame instanceof FrameElement) {
+          return frame;
+        }
+      }
+    }
+  };
+  var History = class {
+    constructor(delegate) {
+      this.restorationIdentifier = uuid();
+      this.restorationData = {};
+      this.started = false;
+      this.pageLoaded = false;
+      this.onPopState = (event) => {
+        if (this.shouldHandlePopState()) {
+          const { turbo } = event.state || {};
+          if (turbo) {
+            this.location = new URL(window.location.href);
+            const { restorationIdentifier } = turbo;
+            this.restorationIdentifier = restorationIdentifier;
+            this.delegate.historyPoppedToLocationWithRestorationIdentifier(this.location, restorationIdentifier);
+          }
+        }
+      };
+      this.onPageLoad = async (_event) => {
+        await nextMicrotask();
+        this.pageLoaded = true;
+      };
+      this.delegate = delegate;
+    }
+    start() {
+      if (!this.started) {
+        addEventListener("popstate", this.onPopState, false);
+        addEventListener("load", this.onPageLoad, false);
+        this.started = true;
+        this.replace(new URL(window.location.href));
+      }
+    }
+    stop() {
+      if (this.started) {
+        removeEventListener("popstate", this.onPopState, false);
+        removeEventListener("load", this.onPageLoad, false);
+        this.started = false;
+      }
+    }
+    push(location2, restorationIdentifier) {
+      this.update(history.pushState, location2, restorationIdentifier);
+    }
+    replace(location2, restorationIdentifier) {
+      this.update(history.replaceState, location2, restorationIdentifier);
+    }
+    update(method, location2, restorationIdentifier = uuid()) {
+      const state = { turbo: { restorationIdentifier } };
+      method.call(history, state, "", location2.href);
+      this.location = location2;
+      this.restorationIdentifier = restorationIdentifier;
+    }
+    getRestorationDataForIdentifier(restorationIdentifier) {
+      return this.restorationData[restorationIdentifier] || {};
+    }
+    updateRestorationData(additionalData) {
+      const { restorationIdentifier } = this;
+      const restorationData = this.restorationData[restorationIdentifier];
+      this.restorationData[restorationIdentifier] = Object.assign(Object.assign({}, restorationData), additionalData);
+    }
+    assumeControlOfScrollRestoration() {
+      var _a;
+      if (!this.previousScrollRestoration) {
+        this.previousScrollRestoration = (_a = history.scrollRestoration) !== null && _a !== void 0 ? _a : "auto";
+        history.scrollRestoration = "manual";
+      }
+    }
+    relinquishControlOfScrollRestoration() {
+      if (this.previousScrollRestoration) {
+        history.scrollRestoration = this.previousScrollRestoration;
+        delete this.previousScrollRestoration;
+      }
+    }
+    shouldHandlePopState() {
+      return this.pageIsLoaded();
+    }
+    pageIsLoaded() {
+      return this.pageLoaded || document.readyState == "complete";
+    }
+  };
+  var Navigator = class {
+    constructor(delegate) {
+      this.delegate = delegate;
+    }
+    proposeVisit(location2, options = {}) {
+      if (this.delegate.allowsVisitingLocationWithAction(location2, options.action)) {
+        if (locationIsVisitable(location2, this.view.snapshot.rootLocation)) {
+          this.delegate.visitProposedToLocation(location2, options);
+        } else {
+          window.location.href = location2.toString();
+        }
+      }
+    }
+    startVisit(locatable, restorationIdentifier, options = {}) {
+      this.lastVisit = this.currentVisit;
+      this.stop();
+      this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, Object.assign({ referrer: this.location }, options));
+      this.currentVisit.start();
+    }
+    submitForm(form, submitter) {
+      this.stop();
+      this.formSubmission = new FormSubmission(this, form, submitter, true);
+      this.formSubmission.start();
+    }
+    stop() {
+      if (this.formSubmission) {
+        this.formSubmission.stop();
+        delete this.formSubmission;
+      }
+      if (this.currentVisit) {
+        this.currentVisit.cancel();
+        delete this.currentVisit;
+      }
+    }
+    get adapter() {
+      return this.delegate.adapter;
+    }
+    get view() {
+      return this.delegate.view;
+    }
+    get history() {
+      return this.delegate.history;
+    }
+    formSubmissionStarted(formSubmission) {
+      if (typeof this.adapter.formSubmissionStarted === "function") {
+        this.adapter.formSubmissionStarted(formSubmission);
+      }
+    }
+    async formSubmissionSucceededWithResponse(formSubmission, fetchResponse) {
+      if (formSubmission == this.formSubmission) {
+        const responseHTML = await fetchResponse.responseHTML;
+        if (responseHTML) {
+          const shouldCacheSnapshot = formSubmission.method == FetchMethod.get;
+          if (!shouldCacheSnapshot) {
+            this.view.clearSnapshotCache();
+          }
+          const { statusCode, redirected } = fetchResponse;
+          const action = this.getActionForFormSubmission(formSubmission);
+          const visitOptions = {
+            action,
+            shouldCacheSnapshot,
+            response: { statusCode, responseHTML, redirected }
+          };
+          this.proposeVisit(fetchResponse.location, visitOptions);
+        }
+      }
+    }
+    async formSubmissionFailedWithResponse(formSubmission, fetchResponse) {
+      const responseHTML = await fetchResponse.responseHTML;
+      if (responseHTML) {
+        const snapshot = PageSnapshot.fromHTMLString(responseHTML);
+        if (fetchResponse.serverError) {
+          await this.view.renderError(snapshot, this.currentVisit);
+        } else {
+          await this.view.renderPage(snapshot, false, true, this.currentVisit);
+        }
+        this.view.scrollToTop();
+        this.view.clearSnapshotCache();
+      }
+    }
+    formSubmissionErrored(formSubmission, error) {
+      console.error(error);
+    }
+    formSubmissionFinished(formSubmission) {
+      if (typeof this.adapter.formSubmissionFinished === "function") {
+        this.adapter.formSubmissionFinished(formSubmission);
+      }
+    }
+    visitStarted(visit2) {
+      this.delegate.visitStarted(visit2);
+    }
+    visitCompleted(visit2) {
+      this.delegate.visitCompleted(visit2);
+    }
+    locationWithActionIsSamePage(location2, action) {
+      var _a;
+      const anchor = getAnchor(location2);
+      const lastLocation = ((_a = this.lastVisit) === null || _a === void 0 ? void 0 : _a.location) || this.view.lastRenderedLocation;
+      const currentAnchor = getAnchor(lastLocation);
+      const isRestorationToTop = action === "restore" && typeof anchor === "undefined";
+      return action !== "replace" && getRequestURL(location2) === getRequestURL(lastLocation) && (isRestorationToTop || anchor != null && anchor !== currentAnchor);
+    }
+    visitScrolledToSamePageLocation(oldURL, newURL) {
+      this.delegate.visitScrolledToSamePageLocation(oldURL, newURL);
+    }
+    get location() {
+      return this.history.location;
+    }
+    get restorationIdentifier() {
+      return this.history.restorationIdentifier;
+    }
+    getActionForFormSubmission(formSubmission) {
+      const { formElement, submitter } = formSubmission;
+      const action = getAttribute("data-turbo-action", submitter, formElement);
+      return isAction(action) ? action : "advance";
+    }
+  };
+  var PageStage;
+  (function(PageStage2) {
+    PageStage2[PageStage2["initial"] = 0] = "initial";
+    PageStage2[PageStage2["loading"] = 1] = "loading";
+    PageStage2[PageStage2["interactive"] = 2] = "interactive";
+    PageStage2[PageStage2["complete"] = 3] = "complete";
+  })(PageStage || (PageStage = {}));
+  var PageObserver = class {
+    constructor(delegate) {
+      this.stage = PageStage.initial;
+      this.started = false;
+      this.interpretReadyState = () => {
+        const { readyState } = this;
+        if (readyState == "interactive") {
+          this.pageIsInteractive();
+        } else if (readyState == "complete") {
+          this.pageIsComplete();
+        }
+      };
+      this.pageWillUnload = () => {
+        this.delegate.pageWillUnload();
+      };
+      this.delegate = delegate;
+    }
+    start() {
+      if (!this.started) {
+        if (this.stage == PageStage.initial) {
+          this.stage = PageStage.loading;
+        }
+        document.addEventListener("readystatechange", this.interpretReadyState, false);
+        addEventListener("pagehide", this.pageWillUnload, false);
+        this.started = true;
+      }
+    }
+    stop() {
+      if (this.started) {
+        document.removeEventListener("readystatechange", this.interpretReadyState, false);
+        removeEventListener("pagehide", this.pageWillUnload, false);
+        this.started = false;
+      }
+    }
+    pageIsInteractive() {
+      if (this.stage == PageStage.loading) {
+        this.stage = PageStage.interactive;
+        this.delegate.pageBecameInteractive();
+      }
+    }
+    pageIsComplete() {
+      this.pageIsInteractive();
+      if (this.stage == PageStage.interactive) {
+        this.stage = PageStage.complete;
+        this.delegate.pageLoaded();
+      }
+    }
+    get readyState() {
+      return document.readyState;
+    }
+  };
+  var ScrollObserver = class {
+    constructor(delegate) {
+      this.started = false;
+      this.onScroll = () => {
+        this.updatePosition({ x: window.pageXOffset, y: window.pageYOffset });
+      };
+      this.delegate = delegate;
+    }
+    start() {
+      if (!this.started) {
+        addEventListener("scroll", this.onScroll, false);
+        this.onScroll();
+        this.started = true;
+      }
+    }
+    stop() {
+      if (this.started) {
+        removeEventListener("scroll", this.onScroll, false);
+        this.started = false;
+      }
+    }
+    updatePosition(position) {
+      this.delegate.scrollPositionChanged(position);
+    }
+  };
+  var StreamMessageRenderer = class {
+    render({ fragment }) {
+      Bardo.preservingPermanentElements(this, getPermanentElementMapForFragment(fragment), () => document.documentElement.appendChild(fragment));
+    }
+    enteringBardo(currentPermanentElement, newPermanentElement) {
+      newPermanentElement.replaceWith(currentPermanentElement.cloneNode(true));
+    }
+    leavingBardo() {
+    }
+  };
+  function getPermanentElementMapForFragment(fragment) {
+    const permanentElementsInDocument = queryPermanentElementsAll(document.documentElement);
+    const permanentElementMap = {};
+    for (const permanentElementInDocument of permanentElementsInDocument) {
+      const { id } = permanentElementInDocument;
+      for (const streamElement of fragment.querySelectorAll("turbo-stream")) {
+        const elementInStream = getPermanentElementById(streamElement.templateElement.content, id);
+        if (elementInStream) {
+          permanentElementMap[id] = [permanentElementInDocument, elementInStream];
+        }
+      }
+    }
+    return permanentElementMap;
+  }
+  var StreamObserver = class {
+    constructor(delegate) {
+      this.sources = new Set();
+      this.started = false;
+      this.inspectFetchResponse = (event) => {
+        const response = fetchResponseFromEvent(event);
+        if (response && fetchResponseIsStream(response)) {
+          event.preventDefault();
+          this.receiveMessageResponse(response);
+        }
+      };
+      this.receiveMessageEvent = (event) => {
+        if (this.started && typeof event.data == "string") {
+          this.receiveMessageHTML(event.data);
+        }
+      };
+      this.delegate = delegate;
+    }
+    start() {
+      if (!this.started) {
+        this.started = true;
+        addEventListener("turbo:before-fetch-response", this.inspectFetchResponse, false);
+      }
+    }
+    stop() {
+      if (this.started) {
+        this.started = false;
+        removeEventListener("turbo:before-fetch-response", this.inspectFetchResponse, false);
+      }
+    }
+    connectStreamSource(source) {
+      if (!this.streamSourceIsConnected(source)) {
+        this.sources.add(source);
+        source.addEventListener("message", this.receiveMessageEvent, false);
+      }
+    }
+    disconnectStreamSource(source) {
+      if (this.streamSourceIsConnected(source)) {
+        this.sources.delete(source);
+        source.removeEventListener("message", this.receiveMessageEvent, false);
+      }
+    }
+    streamSourceIsConnected(source) {
+      return this.sources.has(source);
+    }
+    async receiveMessageResponse(response) {
+      const html = await response.responseHTML;
+      if (html) {
+        this.receiveMessageHTML(html);
+      }
+    }
+    receiveMessageHTML(html) {
+      this.delegate.receivedMessageFromStream(StreamMessage.wrap(html));
+    }
+  };
+  function fetchResponseFromEvent(event) {
+    var _a;
+    const fetchResponse = (_a = event.detail) === null || _a === void 0 ? void 0 : _a.fetchResponse;
+    if (fetchResponse instanceof FetchResponse) {
+      return fetchResponse;
+    }
+  }
+  function fetchResponseIsStream(response) {
+    var _a;
+    const contentType = (_a = response.contentType) !== null && _a !== void 0 ? _a : "";
+    return contentType.startsWith(StreamMessage.contentType);
+  }
+  var ErrorRenderer = class extends Renderer {
+    static renderElement(currentElement, newElement) {
+      const { documentElement, body } = document;
+      documentElement.replaceChild(newElement, body);
+    }
+    async render() {
+      this.replaceHeadAndBody();
+      this.activateScriptElements();
+    }
+    replaceHeadAndBody() {
+      const { documentElement, head } = document;
+      documentElement.replaceChild(this.newHead, head);
+      this.renderElement(this.currentElement, this.newElement);
+    }
+    activateScriptElements() {
+      for (const replaceableElement of this.scriptElements) {
+        const parentNode = replaceableElement.parentNode;
+        if (parentNode) {
+          const element = activateScriptElement(replaceableElement);
+          parentNode.replaceChild(element, replaceableElement);
+        }
+      }
+    }
+    get newHead() {
+      return this.newSnapshot.headSnapshot.element;
+    }
+    get scriptElements() {
+      return document.documentElement.querySelectorAll("script");
+    }
+  };
+  var PageRenderer = class extends Renderer {
+    static renderElement(currentElement, newElement) {
+      if (document.body && newElement instanceof HTMLBodyElement) {
+        document.body.replaceWith(newElement);
+      } else {
+        document.documentElement.appendChild(newElement);
+      }
+    }
+    get shouldRender() {
+      return this.newSnapshot.isVisitable && this.trackedElementsAreIdentical;
+    }
+    get reloadReason() {
+      if (!this.newSnapshot.isVisitable) {
+        return {
+          reason: "turbo_visit_control_is_reload"
+        };
+      }
+      if (!this.trackedElementsAreIdentical) {
+        return {
+          reason: "tracked_element_mismatch"
+        };
+      }
+    }
+    async prepareToRender() {
+      await this.mergeHead();
+    }
+    async render() {
+      if (this.willRender) {
+        this.replaceBody();
+      }
+    }
+    finishRendering() {
+      super.finishRendering();
+      if (!this.isPreview) {
+        this.focusFirstAutofocusableElement();
+      }
+    }
+    get currentHeadSnapshot() {
+      return this.currentSnapshot.headSnapshot;
+    }
+    get newHeadSnapshot() {
+      return this.newSnapshot.headSnapshot;
+    }
+    get newElement() {
+      return this.newSnapshot.element;
+    }
+    async mergeHead() {
+      const newStylesheetElements = this.copyNewHeadStylesheetElements();
+      this.copyNewHeadScriptElements();
+      this.removeCurrentHeadProvisionalElements();
+      this.copyNewHeadProvisionalElements();
+      await newStylesheetElements;
+    }
+    replaceBody() {
+      this.preservingPermanentElements(() => {
+        this.activateNewBody();
+        this.assignNewBody();
+      });
+    }
+    get trackedElementsAreIdentical() {
+      return this.currentHeadSnapshot.trackedElementSignature == this.newHeadSnapshot.trackedElementSignature;
+    }
+    async copyNewHeadStylesheetElements() {
+      const loadingElements = [];
+      for (const element of this.newHeadStylesheetElements) {
+        loadingElements.push(waitForLoad(element));
+        document.head.appendChild(element);
+      }
+      await Promise.all(loadingElements);
+    }
+    copyNewHeadScriptElements() {
+      for (const element of this.newHeadScriptElements) {
+        document.head.appendChild(activateScriptElement(element));
+      }
+    }
+    removeCurrentHeadProvisionalElements() {
+      for (const element of this.currentHeadProvisionalElements) {
+        document.head.removeChild(element);
+      }
+    }
+    copyNewHeadProvisionalElements() {
+      for (const element of this.newHeadProvisionalElements) {
+        document.head.appendChild(element);
+      }
+    }
+    activateNewBody() {
+      document.adoptNode(this.newElement);
+      this.activateNewBodyScriptElements();
+    }
+    activateNewBodyScriptElements() {
+      for (const inertScriptElement of this.newBodyScriptElements) {
+        const activatedScriptElement = activateScriptElement(inertScriptElement);
+        inertScriptElement.replaceWith(activatedScriptElement);
+      }
+    }
+    assignNewBody() {
+      this.renderElement(this.currentElement, this.newElement);
+    }
+    get newHeadStylesheetElements() {
+      return this.newHeadSnapshot.getStylesheetElementsNotInSnapshot(this.currentHeadSnapshot);
+    }
+    get newHeadScriptElements() {
+      return this.newHeadSnapshot.getScriptElementsNotInSnapshot(this.currentHeadSnapshot);
+    }
+    get currentHeadProvisionalElements() {
+      return this.currentHeadSnapshot.provisionalElements;
+    }
+    get newHeadProvisionalElements() {
+      return this.newHeadSnapshot.provisionalElements;
+    }
+    get newBodyScriptElements() {
+      return this.newElement.querySelectorAll("script");
+    }
+  };
+  var SnapshotCache = class {
+    constructor(size) {
+      this.keys = [];
+      this.snapshots = {};
+      this.size = size;
+    }
+    has(location2) {
+      return toCacheKey(location2) in this.snapshots;
+    }
+    get(location2) {
+      if (this.has(location2)) {
+        const snapshot = this.read(location2);
+        this.touch(location2);
+        return snapshot;
+      }
+    }
+    put(location2, snapshot) {
+      this.write(location2, snapshot);
+      this.touch(location2);
+      return snapshot;
+    }
+    clear() {
+      this.snapshots = {};
+    }
+    read(location2) {
+      return this.snapshots[toCacheKey(location2)];
+    }
+    write(location2, snapshot) {
+      this.snapshots[toCacheKey(location2)] = snapshot;
+    }
+    touch(location2) {
+      const key = toCacheKey(location2);
+      const index = this.keys.indexOf(key);
+      if (index > -1)
+        this.keys.splice(index, 1);
+      this.keys.unshift(key);
+      this.trim();
+    }
+    trim() {
+      for (const key of this.keys.splice(this.size)) {
+        delete this.snapshots[key];
+      }
+    }
+  };
+  var PageView = class extends View {
+    constructor() {
+      super(...arguments);
+      this.snapshotCache = new SnapshotCache(10);
+      this.lastRenderedLocation = new URL(location.href);
+      this.forceReloaded = false;
+    }
+    renderPage(snapshot, isPreview = false, willRender = true, visit2) {
+      const renderer = new PageRenderer(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender);
+      if (!renderer.shouldRender) {
+        this.forceReloaded = true;
+      } else {
+        visit2 === null || visit2 === void 0 ? void 0 : visit2.changeHistory();
+      }
+      return this.render(renderer);
+    }
+    renderError(snapshot, visit2) {
+      visit2 === null || visit2 === void 0 ? void 0 : visit2.changeHistory();
+      const renderer = new ErrorRenderer(this.snapshot, snapshot, ErrorRenderer.renderElement, false);
+      return this.render(renderer);
+    }
+    clearSnapshotCache() {
+      this.snapshotCache.clear();
+    }
+    async cacheSnapshot() {
+      if (this.shouldCacheSnapshot) {
+        this.delegate.viewWillCacheSnapshot();
+        const { snapshot, lastRenderedLocation: location2 } = this;
+        await nextEventLoopTick();
+        const cachedSnapshot = snapshot.clone();
+        this.snapshotCache.put(location2, cachedSnapshot);
+        return cachedSnapshot;
+      }
+    }
+    getCachedSnapshotForLocation(location2) {
+      return this.snapshotCache.get(location2);
+    }
+    get snapshot() {
+      return PageSnapshot.fromElement(this.element);
+    }
+    get shouldCacheSnapshot() {
+      return this.snapshot.isCacheable;
+    }
+  };
+  var Preloader = class {
+    constructor(delegate) {
+      this.selector = "a[data-turbo-preload]";
+      this.delegate = delegate;
+    }
+    get snapshotCache() {
+      return this.delegate.navigator.view.snapshotCache;
+    }
+    start() {
+      if (document.readyState === "loading") {
+        return document.addEventListener("DOMContentLoaded", () => {
+          this.preloadOnLoadLinksForView(document.body);
+        });
+      } else {
+        this.preloadOnLoadLinksForView(document.body);
+      }
+    }
+    preloadOnLoadLinksForView(element) {
+      for (const link of element.querySelectorAll(this.selector)) {
+        this.preloadURL(link);
+      }
+    }
+    async preloadURL(link) {
+      const location2 = new URL(link.href);
+      if (this.snapshotCache.has(location2)) {
+        return;
+      }
+      try {
+        const response = await fetch(location2.toString(), { headers: { "VND.PREFETCH": "true", Accept: "text/html" } });
+        const responseText = await response.text();
+        const snapshot = PageSnapshot.fromHTMLString(responseText);
+        this.snapshotCache.put(location2, snapshot);
+      } catch (_) {
+      }
+    }
+  };
+  var Session = class {
+    constructor() {
+      this.navigator = new Navigator(this);
+      this.history = new History(this);
+      this.preloader = new Preloader(this);
+      this.view = new PageView(this, document.documentElement);
+      this.adapter = new BrowserAdapter(this);
+      this.pageObserver = new PageObserver(this);
+      this.cacheObserver = new CacheObserver();
+      this.linkClickObserver = new LinkClickObserver(this, window);
+      this.formSubmitObserver = new FormSubmitObserver(this, document);
+      this.scrollObserver = new ScrollObserver(this);
+      this.streamObserver = new StreamObserver(this);
+      this.formLinkClickObserver = new FormLinkClickObserver(this, document.documentElement);
+      this.frameRedirector = new FrameRedirector(this, document.documentElement);
+      this.streamMessageRenderer = new StreamMessageRenderer();
+      this.drive = true;
+      this.enabled = true;
+      this.progressBarDelay = 500;
+      this.started = false;
+      this.formMode = "on";
+    }
+    start() {
+      if (!this.started) {
+        this.pageObserver.start();
+        this.cacheObserver.start();
+        this.formLinkClickObserver.start();
+        this.linkClickObserver.start();
+        this.formSubmitObserver.start();
+        this.scrollObserver.start();
+        this.streamObserver.start();
+        this.frameRedirector.start();
+        this.history.start();
+        this.preloader.start();
+        this.started = true;
+        this.enabled = true;
+      }
+    }
+    disable() {
+      this.enabled = false;
+    }
+    stop() {
+      if (this.started) {
+        this.pageObserver.stop();
+        this.cacheObserver.stop();
+        this.formLinkClickObserver.stop();
+        this.linkClickObserver.stop();
+        this.formSubmitObserver.stop();
+        this.scrollObserver.stop();
+        this.streamObserver.stop();
+        this.frameRedirector.stop();
+        this.history.stop();
+        this.started = false;
+      }
+    }
+    registerAdapter(adapter) {
+      this.adapter = adapter;
+    }
+    visit(location2, options = {}) {
+      const frameElement = options.frame ? document.getElementById(options.frame) : null;
+      if (frameElement instanceof FrameElement) {
+        frameElement.src = location2.toString();
+        frameElement.loaded;
+      } else {
+        this.navigator.proposeVisit(expandURL(location2), options);
+      }
+    }
+    connectStreamSource(source) {
+      this.streamObserver.connectStreamSource(source);
+    }
+    disconnectStreamSource(source) {
+      this.streamObserver.disconnectStreamSource(source);
+    }
+    renderStreamMessage(message) {
+      this.streamMessageRenderer.render(StreamMessage.wrap(message));
+    }
+    clearCache() {
+      this.view.clearSnapshotCache();
+    }
+    setProgressBarDelay(delay) {
+      this.progressBarDelay = delay;
+    }
+    setFormMode(mode) {
+      this.formMode = mode;
+    }
+    get location() {
+      return this.history.location;
+    }
+    get restorationIdentifier() {
+      return this.history.restorationIdentifier;
+    }
+    historyPoppedToLocationWithRestorationIdentifier(location2, restorationIdentifier) {
+      if (this.enabled) {
+        this.navigator.startVisit(location2, restorationIdentifier, {
+          action: "restore",
+          historyChanged: true
+        });
+      } else {
+        this.adapter.pageInvalidated({
+          reason: "turbo_disabled"
+        });
+      }
+    }
+    scrollPositionChanged(position) {
+      this.history.updateRestorationData({ scrollPosition: position });
+    }
+    willSubmitFormLinkToLocation(link, location2) {
+      return this.elementIsNavigatable(link) && locationIsVisitable(location2, this.snapshot.rootLocation);
+    }
+    submittedFormLinkToLocation() {
+    }
+    willFollowLinkToLocation(link, location2, event) {
+      return this.elementIsNavigatable(link) && locationIsVisitable(location2, this.snapshot.rootLocation) && this.applicationAllowsFollowingLinkToLocation(link, location2, event);
+    }
+    followedLinkToLocation(link, location2) {
+      const action = this.getActionForLink(link);
+      const acceptsStreamResponse = link.hasAttribute("data-turbo-stream");
+      this.visit(location2.href, { action, acceptsStreamResponse });
+    }
+    allowsVisitingLocationWithAction(location2, action) {
+      return this.locationWithActionIsSamePage(location2, action) || this.applicationAllowsVisitingLocation(location2);
+    }
+    visitProposedToLocation(location2, options) {
+      extendURLWithDeprecatedProperties(location2);
+      this.adapter.visitProposedToLocation(location2, options);
+    }
+    visitStarted(visit2) {
+      if (!visit2.acceptsStreamResponse) {
+        markAsBusy(document.documentElement);
+      }
+      extendURLWithDeprecatedProperties(visit2.location);
+      if (!visit2.silent) {
+        this.notifyApplicationAfterVisitingLocation(visit2.location, visit2.action);
+      }
+    }
+    visitCompleted(visit2) {
+      clearBusyState(document.documentElement);
+      this.notifyApplicationAfterPageLoad(visit2.getTimingMetrics());
+    }
+    locationWithActionIsSamePage(location2, action) {
+      return this.navigator.locationWithActionIsSamePage(location2, action);
+    }
+    visitScrolledToSamePageLocation(oldURL, newURL) {
+      this.notifyApplicationAfterVisitingSamePageLocation(oldURL, newURL);
+    }
+    willSubmitForm(form, submitter) {
+      const action = getAction(form, submitter);
+      return this.submissionIsNavigatable(form, submitter) && locationIsVisitable(expandURL(action), this.snapshot.rootLocation);
+    }
+    formSubmitted(form, submitter) {
+      this.navigator.submitForm(form, submitter);
+    }
+    pageBecameInteractive() {
+      this.view.lastRenderedLocation = this.location;
+      this.notifyApplicationAfterPageLoad();
+    }
+    pageLoaded() {
+      this.history.assumeControlOfScrollRestoration();
+    }
+    pageWillUnload() {
+      this.history.relinquishControlOfScrollRestoration();
+    }
+    receivedMessageFromStream(message) {
+      this.renderStreamMessage(message);
+    }
+    viewWillCacheSnapshot() {
+      var _a;
+      if (!((_a = this.navigator.currentVisit) === null || _a === void 0 ? void 0 : _a.silent)) {
+        this.notifyApplicationBeforeCachingSnapshot();
+      }
+    }
+    allowsImmediateRender({ element }, options) {
+      const event = this.notifyApplicationBeforeRender(element, options);
+      const { defaultPrevented, detail: { render } } = event;
+      if (this.view.renderer && render) {
+        this.view.renderer.renderElement = render;
+      }
+      return !defaultPrevented;
+    }
+    viewRenderedSnapshot(_snapshot, _isPreview) {
+      this.view.lastRenderedLocation = this.history.location;
+      this.notifyApplicationAfterRender();
+    }
+    preloadOnLoadLinksForView(element) {
+      this.preloader.preloadOnLoadLinksForView(element);
+    }
+    viewInvalidated(reason) {
+      this.adapter.pageInvalidated(reason);
+    }
+    frameLoaded(frame) {
+      this.notifyApplicationAfterFrameLoad(frame);
+    }
+    frameRendered(fetchResponse, frame) {
+      this.notifyApplicationAfterFrameRender(fetchResponse, frame);
+    }
+    applicationAllowsFollowingLinkToLocation(link, location2, ev) {
+      const event = this.notifyApplicationAfterClickingLinkToLocation(link, location2, ev);
+      return !event.defaultPrevented;
+    }
+    applicationAllowsVisitingLocation(location2) {
+      const event = this.notifyApplicationBeforeVisitingLocation(location2);
+      return !event.defaultPrevented;
+    }
+    notifyApplicationAfterClickingLinkToLocation(link, location2, event) {
+      return dispatch("turbo:click", {
+        target: link,
+        detail: { url: location2.href, originalEvent: event },
+        cancelable: true
+      });
+    }
+    notifyApplicationBeforeVisitingLocation(location2) {
+      return dispatch("turbo:before-visit", {
+        detail: { url: location2.href },
+        cancelable: true
+      });
+    }
+    notifyApplicationAfterVisitingLocation(location2, action) {
+      return dispatch("turbo:visit", { detail: { url: location2.href, action } });
+    }
+    notifyApplicationBeforeCachingSnapshot() {
+      return dispatch("turbo:before-cache");
+    }
+    notifyApplicationBeforeRender(newBody, options) {
+      return dispatch("turbo:before-render", {
+        detail: Object.assign({ newBody }, options),
+        cancelable: true
+      });
+    }
+    notifyApplicationAfterRender() {
+      return dispatch("turbo:render");
+    }
+    notifyApplicationAfterPageLoad(timing = {}) {
+      return dispatch("turbo:load", {
+        detail: { url: this.location.href, timing }
+      });
+    }
+    notifyApplicationAfterVisitingSamePageLocation(oldURL, newURL) {
+      dispatchEvent(new HashChangeEvent("hashchange", {
+        oldURL: oldURL.toString(),
+        newURL: newURL.toString()
+      }));
+    }
+    notifyApplicationAfterFrameLoad(frame) {
+      return dispatch("turbo:frame-load", { target: frame });
+    }
+    notifyApplicationAfterFrameRender(fetchResponse, frame) {
+      return dispatch("turbo:frame-render", {
+        detail: { fetchResponse },
+        target: frame,
+        cancelable: true
+      });
+    }
+    submissionIsNavigatable(form, submitter) {
+      if (this.formMode == "off") {
+        return false;
+      } else {
+        const submitterIsNavigatable = submitter ? this.elementIsNavigatable(submitter) : true;
+        if (this.formMode == "optin") {
+          return submitterIsNavigatable && form.closest('[data-turbo="true"]') != null;
+        } else {
+          return submitterIsNavigatable && this.elementIsNavigatable(form);
+        }
+      }
+    }
+    elementIsNavigatable(element) {
+      const container = element.closest("[data-turbo]");
+      const withinFrame = element.closest("turbo-frame");
+      if (this.drive || withinFrame) {
+        if (container) {
+          return container.getAttribute("data-turbo") != "false";
+        } else {
+          return true;
+        }
+      } else {
+        if (container) {
+          return container.getAttribute("data-turbo") == "true";
+        } else {
+          return false;
+        }
+      }
+    }
+    getActionForLink(link) {
+      const action = link.getAttribute("data-turbo-action");
+      return isAction(action) ? action : "advance";
+    }
+    get snapshot() {
+      return this.view.snapshot;
+    }
+  };
+  function extendURLWithDeprecatedProperties(url) {
+    Object.defineProperties(url, deprecatedLocationPropertyDescriptors);
+  }
+  var deprecatedLocationPropertyDescriptors = {
+    absoluteURL: {
+      get() {
+        return this.toString();
+      }
+    }
+  };
+  var Cache = class {
+    constructor(session2) {
+      this.session = session2;
+    }
+    clear() {
+      this.session.clearCache();
+    }
+    resetCacheControl() {
+      this.setCacheControl("");
+    }
+    exemptPageFromCache() {
+      this.setCacheControl("no-cache");
+    }
+    exemptPageFromPreview() {
+      this.setCacheControl("no-preview");
+    }
+    setCacheControl(value) {
+      setMetaContent("turbo-cache-control", value);
+    }
+  };
+  var StreamActions = {
+    after() {
+      this.targetElements.forEach((e) => {
+        var _a;
+        return (_a = e.parentElement) === null || _a === void 0 ? void 0 : _a.insertBefore(this.templateContent, e.nextSibling);
+      });
+    },
+    append() {
+      this.removeDuplicateTargetChildren();
+      this.targetElements.forEach((e) => e.append(this.templateContent));
+    },
+    before() {
+      this.targetElements.forEach((e) => {
+        var _a;
+        return (_a = e.parentElement) === null || _a === void 0 ? void 0 : _a.insertBefore(this.templateContent, e);
+      });
+    },
+    prepend() {
+      this.removeDuplicateTargetChildren();
+      this.targetElements.forEach((e) => e.prepend(this.templateContent));
+    },
+    remove() {
+      this.targetElements.forEach((e) => e.remove());
+    },
+    replace() {
+      this.targetElements.forEach((e) => e.replaceWith(this.templateContent));
+    },
+    update() {
+      this.targetElements.forEach((e) => e.replaceChildren(this.templateContent));
+    }
+  };
+  var session = new Session();
+  var cache = new Cache(session);
+  var { navigator: navigator$1 } = session;
+  function start() {
+    session.start();
+  }
+  function registerAdapter(adapter) {
+    session.registerAdapter(adapter);
+  }
+  function visit(location2, options) {
+    session.visit(location2, options);
+  }
+  function connectStreamSource(source) {
+    session.connectStreamSource(source);
+  }
+  function disconnectStreamSource(source) {
+    session.disconnectStreamSource(source);
+  }
+  function renderStreamMessage(message) {
+    session.renderStreamMessage(message);
+  }
+  function clearCache() {
+    console.warn("Please replace `Turbo.clearCache()` with `Turbo.cache.clear()`. The top-level function is deprecated and will be removed in a future version of Turbo.`");
+    session.clearCache();
+  }
+  function setProgressBarDelay(delay) {
+    session.setProgressBarDelay(delay);
+  }
+  function setConfirmMethod(confirmMethod) {
+    FormSubmission.confirmMethod = confirmMethod;
+  }
+  function setFormMode(mode) {
+    session.setFormMode(mode);
+  }
+  var Turbo = /* @__PURE__ */ Object.freeze({
+    __proto__: null,
+    navigator: navigator$1,
+    session,
+    cache,
+    PageRenderer,
+    PageSnapshot,
+    FrameRenderer,
+    start,
+    registerAdapter,
+    visit,
+    connectStreamSource,
+    disconnectStreamSource,
+    renderStreamMessage,
+    clearCache,
+    setProgressBarDelay,
+    setConfirmMethod,
+    setFormMode,
+    StreamActions
+  });
+  var FrameController = class {
+    constructor(element) {
+      this.fetchResponseLoaded = (_fetchResponse) => {
+      };
+      this.currentFetchRequest = null;
+      this.resolveVisitPromise = () => {
+      };
+      this.connected = false;
+      this.hasBeenLoaded = false;
+      this.ignoredAttributes = new Set();
+      this.action = null;
+      this.visitCachedSnapshot = ({ element: element2 }) => {
+        const frame = element2.querySelector("#" + this.element.id);
+        if (frame && this.previousFrameElement) {
+          frame.replaceChildren(...this.previousFrameElement.children);
+        }
+        delete this.previousFrameElement;
+      };
+      this.element = element;
+      this.view = new FrameView(this, this.element);
+      this.appearanceObserver = new AppearanceObserver(this, this.element);
+      this.formLinkClickObserver = new FormLinkClickObserver(this, this.element);
+      this.linkClickObserver = new LinkClickObserver(this, this.element);
+      this.restorationIdentifier = uuid();
+      this.formSubmitObserver = new FormSubmitObserver(this, this.element);
+    }
+    connect() {
+      if (!this.connected) {
+        this.connected = true;
+        if (this.loadingStyle == FrameLoadingStyle.lazy) {
+          this.appearanceObserver.start();
+        } else {
+          this.loadSourceURL();
+        }
+        this.formLinkClickObserver.start();
+        this.linkClickObserver.start();
+        this.formSubmitObserver.start();
+      }
+    }
+    disconnect() {
+      if (this.connected) {
+        this.connected = false;
+        this.appearanceObserver.stop();
+        this.formLinkClickObserver.stop();
+        this.linkClickObserver.stop();
+        this.formSubmitObserver.stop();
+      }
+    }
+    disabledChanged() {
+      if (this.loadingStyle == FrameLoadingStyle.eager) {
+        this.loadSourceURL();
+      }
+    }
+    sourceURLChanged() {
+      if (this.isIgnoringChangesTo("src"))
+        return;
+      if (this.element.isConnected) {
+        this.complete = false;
+      }
+      if (this.loadingStyle == FrameLoadingStyle.eager || this.hasBeenLoaded) {
+        this.loadSourceURL();
+      }
+    }
+    completeChanged() {
+      if (this.isIgnoringChangesTo("complete"))
+        return;
+      this.loadSourceURL();
+    }
+    loadingStyleChanged() {
+      if (this.loadingStyle == FrameLoadingStyle.lazy) {
+        this.appearanceObserver.start();
+      } else {
+        this.appearanceObserver.stop();
+        this.loadSourceURL();
+      }
+    }
+    async loadSourceURL() {
+      if (this.enabled && this.isActive && !this.complete && this.sourceURL) {
+        this.element.loaded = this.visit(expandURL(this.sourceURL));
+        this.appearanceObserver.stop();
+        await this.element.loaded;
+        this.hasBeenLoaded = true;
+      }
+    }
+    async loadResponse(fetchResponse) {
+      if (fetchResponse.redirected || fetchResponse.succeeded && fetchResponse.isHTML) {
+        this.sourceURL = fetchResponse.response.url;
+      }
+      try {
+        const html = await fetchResponse.responseHTML;
+        if (html) {
+          const { body } = parseHTMLDocument(html);
+          const newFrameElement = await this.extractForeignFrameElement(body);
+          if (newFrameElement) {
+            const snapshot = new Snapshot(newFrameElement);
+            const renderer = new FrameRenderer(this, this.view.snapshot, snapshot, FrameRenderer.renderElement, false, false);
+            if (this.view.renderPromise)
+              await this.view.renderPromise;
+            this.changeHistory();
+            await this.view.render(renderer);
+            this.complete = true;
+            session.frameRendered(fetchResponse, this.element);
+            session.frameLoaded(this.element);
+            this.fetchResponseLoaded(fetchResponse);
+          } else if (this.willHandleFrameMissingFromResponse(fetchResponse)) {
+            console.warn(`A matching frame for #${this.element.id} was missing from the response, transforming into full-page Visit.`);
+            this.visitResponse(fetchResponse.response);
+          }
+        }
+      } catch (error) {
+        console.error(error);
+        this.view.invalidate();
+      } finally {
+        this.fetchResponseLoaded = () => {
+        };
+      }
+    }
+    elementAppearedInViewport(_element) {
+      this.loadSourceURL();
+    }
+    willSubmitFormLinkToLocation(link) {
+      return link.closest("turbo-frame") == this.element && this.shouldInterceptNavigation(link);
+    }
+    submittedFormLinkToLocation(link, _location, form) {
+      const frame = this.findFrameElement(link);
+      if (frame)
+        form.setAttribute("data-turbo-frame", frame.id);
+    }
+    willFollowLinkToLocation(element, location2, event) {
+      return this.shouldInterceptNavigation(element) && this.frameAllowsVisitingLocation(element, location2, event);
+    }
+    followedLinkToLocation(element, location2) {
+      this.navigateFrame(element, location2.href);
+    }
+    willSubmitForm(element, submitter) {
+      return element.closest("turbo-frame") == this.element && this.shouldInterceptNavigation(element, submitter);
+    }
+    formSubmitted(element, submitter) {
+      if (this.formSubmission) {
+        this.formSubmission.stop();
+      }
+      this.formSubmission = new FormSubmission(this, element, submitter);
+      const { fetchRequest } = this.formSubmission;
+      this.prepareHeadersForRequest(fetchRequest.headers, fetchRequest);
+      this.formSubmission.start();
+    }
+    prepareHeadersForRequest(headers, request) {
+      var _a;
+      headers["Turbo-Frame"] = this.id;
+      if ((_a = this.currentNavigationElement) === null || _a === void 0 ? void 0 : _a.hasAttribute("data-turbo-stream")) {
+        request.acceptResponseType(StreamMessage.contentType);
+      }
+    }
+    requestStarted(_request) {
+      markAsBusy(this.element);
+    }
+    requestPreventedHandlingResponse(_request, _response) {
+      this.resolveVisitPromise();
+    }
+    async requestSucceededWithResponse(request, response) {
+      await this.loadResponse(response);
+      this.resolveVisitPromise();
+    }
+    async requestFailedWithResponse(request, response) {
+      console.error(response);
+      await this.loadResponse(response);
+      this.resolveVisitPromise();
+    }
+    requestErrored(request, error) {
+      console.error(error);
+      this.resolveVisitPromise();
+    }
+    requestFinished(_request) {
+      clearBusyState(this.element);
+    }
+    formSubmissionStarted({ formElement }) {
+      markAsBusy(formElement, this.findFrameElement(formElement));
+    }
+    formSubmissionSucceededWithResponse(formSubmission, response) {
+      const frame = this.findFrameElement(formSubmission.formElement, formSubmission.submitter);
+      this.proposeVisitIfNavigatedWithAction(frame, formSubmission.formElement, formSubmission.submitter);
+      frame.delegate.loadResponse(response);
+    }
+    formSubmissionFailedWithResponse(formSubmission, fetchResponse) {
+      this.element.delegate.loadResponse(fetchResponse);
+    }
+    formSubmissionErrored(formSubmission, error) {
+      console.error(error);
+    }
+    formSubmissionFinished({ formElement }) {
+      clearBusyState(formElement, this.findFrameElement(formElement));
+    }
+    allowsImmediateRender({ element: newFrame }, options) {
+      const event = dispatch("turbo:before-frame-render", {
+        target: this.element,
+        detail: Object.assign({ newFrame }, options),
+        cancelable: true
+      });
+      const { defaultPrevented, detail: { render } } = event;
+      if (this.view.renderer && render) {
+        this.view.renderer.renderElement = render;
+      }
+      return !defaultPrevented;
+    }
+    viewRenderedSnapshot(_snapshot, _isPreview) {
+    }
+    preloadOnLoadLinksForView(element) {
+      session.preloadOnLoadLinksForView(element);
+    }
+    viewInvalidated() {
+    }
+    willRenderFrame(currentElement, _newElement) {
+      this.previousFrameElement = currentElement.cloneNode(true);
+    }
+    async visit(url) {
+      var _a;
+      const request = new FetchRequest(this, FetchMethod.get, url, new URLSearchParams(), this.element);
+      (_a = this.currentFetchRequest) === null || _a === void 0 ? void 0 : _a.cancel();
+      this.currentFetchRequest = request;
+      return new Promise((resolve) => {
+        this.resolveVisitPromise = () => {
+          this.resolveVisitPromise = () => {
+          };
+          this.currentFetchRequest = null;
+          resolve();
+        };
+        request.perform();
+      });
+    }
+    navigateFrame(element, url, submitter) {
+      const frame = this.findFrameElement(element, submitter);
+      this.proposeVisitIfNavigatedWithAction(frame, element, submitter);
+      this.withCurrentNavigationElement(element, () => {
+        frame.src = url;
+      });
+    }
+    proposeVisitIfNavigatedWithAction(frame, element, submitter) {
+      this.action = getVisitAction(submitter, element, frame);
+      this.frame = frame;
+      if (isAction(this.action)) {
+        const { visitCachedSnapshot } = frame.delegate;
+        frame.delegate.fetchResponseLoaded = (fetchResponse) => {
+          if (frame.src) {
+            const { statusCode, redirected } = fetchResponse;
+            const responseHTML = frame.ownerDocument.documentElement.outerHTML;
+            const response = { statusCode, redirected, responseHTML };
+            const options = {
+              response,
+              visitCachedSnapshot,
+              willRender: false,
+              updateHistory: false,
+              restorationIdentifier: this.restorationIdentifier
+            };
+            if (this.action)
+              options.action = this.action;
+            session.visit(frame.src, options);
+          }
+        };
+      }
+    }
+    changeHistory() {
+      if (this.action && this.frame) {
+        const method = getHistoryMethodForAction(this.action);
+        session.history.update(method, expandURL(this.frame.src || ""), this.restorationIdentifier);
+      }
+    }
+    willHandleFrameMissingFromResponse(fetchResponse) {
+      this.element.setAttribute("complete", "");
+      const response = fetchResponse.response;
+      const visit2 = async (url, options = {}) => {
+        if (url instanceof Response) {
+          this.visitResponse(url);
+        } else {
+          session.visit(url, options);
+        }
+      };
+      const event = dispatch("turbo:frame-missing", {
+        target: this.element,
+        detail: { response, visit: visit2 },
+        cancelable: true
+      });
+      return !event.defaultPrevented;
+    }
+    async visitResponse(response) {
+      const wrapped = new FetchResponse(response);
+      const responseHTML = await wrapped.responseHTML;
+      const { location: location2, redirected, statusCode } = wrapped;
+      return session.visit(location2, { response: { redirected, statusCode, responseHTML } });
+    }
+    findFrameElement(element, submitter) {
+      var _a;
+      const id = getAttribute("data-turbo-frame", submitter, element) || this.element.getAttribute("target");
+      return (_a = getFrameElementById(id)) !== null && _a !== void 0 ? _a : this.element;
+    }
+    async extractForeignFrameElement(container) {
+      let element;
+      const id = CSS.escape(this.id);
+      try {
+        element = activateElement(container.querySelector(`turbo-frame#${id}`), this.sourceURL);
+        if (element) {
+          return element;
+        }
+        element = activateElement(container.querySelector(`turbo-frame[src][recurse~=${id}]`), this.sourceURL);
+        if (element) {
+          await element.loaded;
+          return await this.extractForeignFrameElement(element);
+        }
+      } catch (error) {
+        console.error(error);
+        return new FrameElement();
+      }
+      return null;
+    }
+    formActionIsVisitable(form, submitter) {
+      const action = getAction(form, submitter);
+      return locationIsVisitable(expandURL(action), this.rootLocation);
+    }
+    shouldInterceptNavigation(element, submitter) {
+      const id = getAttribute("data-turbo-frame", submitter, element) || this.element.getAttribute("target");
+      if (element instanceof HTMLFormElement && !this.formActionIsVisitable(element, submitter)) {
+        return false;
+      }
+      if (!this.enabled || id == "_top") {
+        return false;
+      }
+      if (id) {
+        const frameElement = getFrameElementById(id);
+        if (frameElement) {
+          return !frameElement.disabled;
+        }
+      }
+      if (!session.elementIsNavigatable(element)) {
+        return false;
+      }
+      if (submitter && !session.elementIsNavigatable(submitter)) {
+        return false;
+      }
+      return true;
+    }
+    get id() {
+      return this.element.id;
+    }
+    get enabled() {
+      return !this.element.disabled;
+    }
+    get sourceURL() {
+      if (this.element.src) {
+        return this.element.src;
+      }
+    }
+    set sourceURL(sourceURL) {
+      this.ignoringChangesToAttribute("src", () => {
+        this.element.src = sourceURL !== null && sourceURL !== void 0 ? sourceURL : null;
+      });
+    }
+    get loadingStyle() {
+      return this.element.loading;
+    }
+    get isLoading() {
+      return this.formSubmission !== void 0 || this.resolveVisitPromise() !== void 0;
+    }
+    get complete() {
+      return this.element.hasAttribute("complete");
+    }
+    set complete(value) {
+      this.ignoringChangesToAttribute("complete", () => {
+        if (value) {
+          this.element.setAttribute("complete", "");
+        } else {
+          this.element.removeAttribute("complete");
+        }
+      });
+    }
+    get isActive() {
+      return this.element.isActive && this.connected;
+    }
+    get rootLocation() {
+      var _a;
+      const meta = this.element.ownerDocument.querySelector(`meta[name="turbo-root"]`);
+      const root = (_a = meta === null || meta === void 0 ? void 0 : meta.content) !== null && _a !== void 0 ? _a : "/";
+      return expandURL(root);
+    }
+    frameAllowsVisitingLocation(target, { href: url }, originalEvent) {
+      const event = dispatch("turbo:click", {
+        target,
+        detail: { url, originalEvent },
+        cancelable: true
+      });
+      return !event.defaultPrevented;
+    }
+    isIgnoringChangesTo(attributeName) {
+      return this.ignoredAttributes.has(attributeName);
+    }
+    ignoringChangesToAttribute(attributeName, callback) {
+      this.ignoredAttributes.add(attributeName);
+      callback();
+      this.ignoredAttributes.delete(attributeName);
+    }
+    withCurrentNavigationElement(element, callback) {
+      this.currentNavigationElement = element;
+      callback();
+      delete this.currentNavigationElement;
+    }
+  };
+  function getFrameElementById(id) {
+    if (id != null) {
+      const element = document.getElementById(id);
+      if (element instanceof FrameElement) {
+        return element;
+      }
+    }
+  }
+  function activateElement(element, currentURL) {
+    if (element) {
+      const src = element.getAttribute("src");
+      if (src != null && currentURL != null && urlsAreEqual(src, currentURL)) {
+        throw new Error(`Matching <turbo-frame id="${element.id}"> element has a source URL which references itself`);
+      }
+      if (element.ownerDocument !== document) {
+        element = document.importNode(element, true);
+      }
+      if (element instanceof FrameElement) {
+        element.connectedCallback();
+        element.disconnectedCallback();
+        return element;
+      }
+    }
+  }
+  var StreamElement = class extends HTMLElement {
+    static async renderElement(newElement) {
+      await newElement.performAction();
+    }
+    async connectedCallback() {
+      try {
+        await this.render();
+      } catch (error) {
+        console.error(error);
+      } finally {
+        this.disconnect();
+      }
+    }
+    async render() {
+      var _a;
+      return (_a = this.renderPromise) !== null && _a !== void 0 ? _a : this.renderPromise = (async () => {
+        const event = this.beforeRenderEvent;
+        if (this.dispatchEvent(event)) {
+          await nextAnimationFrame();
+          await event.detail.render(this);
+        }
+      })();
+    }
+    disconnect() {
+      try {
+        this.remove();
+      } catch (_a) {
+      }
+    }
+    removeDuplicateTargetChildren() {
+      this.duplicateChildren.forEach((c) => c.remove());
+    }
+    get duplicateChildren() {
+      var _a;
+      const existingChildren = this.targetElements.flatMap((e) => [...e.children]).filter((c) => !!c.id);
+      const newChildrenIds = [...((_a = this.templateContent) === null || _a === void 0 ? void 0 : _a.children) || []].filter((c) => !!c.id).map((c) => c.id);
+      return existingChildren.filter((c) => newChildrenIds.includes(c.id));
+    }
+    get performAction() {
+      if (this.action) {
+        const actionFunction = StreamActions[this.action];
+        if (actionFunction) {
+          return actionFunction;
+        }
+        this.raise("unknown action");
+      }
+      this.raise("action attribute is missing");
+    }
+    get targetElements() {
+      if (this.target) {
+        return this.targetElementsById;
+      } else if (this.targets) {
+        return this.targetElementsByQuery;
+      } else {
+        this.raise("target or targets attribute is missing");
+      }
+    }
+    get templateContent() {
+      return this.templateElement.content.cloneNode(true);
+    }
+    get templateElement() {
+      if (this.firstElementChild === null) {
+        const template = this.ownerDocument.createElement("template");
+        this.appendChild(template);
+        return template;
+      } else if (this.firstElementChild instanceof HTMLTemplateElement) {
+        return this.firstElementChild;
+      }
+      this.raise("first child element must be a <template> element");
+    }
+    get action() {
+      return this.getAttribute("action");
+    }
+    get target() {
+      return this.getAttribute("target");
+    }
+    get targets() {
+      return this.getAttribute("targets");
+    }
+    raise(message) {
+      throw new Error(`${this.description}: ${message}`);
+    }
+    get description() {
+      var _a, _b;
+      return (_b = ((_a = this.outerHTML.match(/<[^>]+>/)) !== null && _a !== void 0 ? _a : [])[0]) !== null && _b !== void 0 ? _b : "<turbo-stream>";
+    }
+    get beforeRenderEvent() {
+      return new CustomEvent("turbo:before-stream-render", {
+        bubbles: true,
+        cancelable: true,
+        detail: { newStream: this, render: StreamElement.renderElement }
+      });
+    }
+    get targetElementsById() {
+      var _a;
+      const element = (_a = this.ownerDocument) === null || _a === void 0 ? void 0 : _a.getElementById(this.target);
+      if (element !== null) {
+        return [element];
+      } else {
+        return [];
+      }
+    }
+    get targetElementsByQuery() {
+      var _a;
+      const elements = (_a = this.ownerDocument) === null || _a === void 0 ? void 0 : _a.querySelectorAll(this.targets);
+      if (elements.length !== 0) {
+        return Array.prototype.slice.call(elements);
+      } else {
+        return [];
+      }
+    }
+  };
+  var StreamSourceElement = class extends HTMLElement {
+    constructor() {
+      super(...arguments);
+      this.streamSource = null;
+    }
+    connectedCallback() {
+      this.streamSource = this.src.match(/^ws{1,2}:/) ? new WebSocket(this.src) : new EventSource(this.src);
+      connectStreamSource(this.streamSource);
+    }
+    disconnectedCallback() {
+      if (this.streamSource) {
+        disconnectStreamSource(this.streamSource);
+      }
+    }
+    get src() {
+      return this.getAttribute("src") || "";
+    }
+  };
+  FrameElement.delegateConstructor = FrameController;
+  if (customElements.get("turbo-frame") === void 0) {
+    customElements.define("turbo-frame", FrameElement);
+  }
+  if (customElements.get("turbo-stream") === void 0) {
+    customElements.define("turbo-stream", StreamElement);
+  }
+  if (customElements.get("turbo-stream-source") === void 0) {
+    customElements.define("turbo-stream-source", StreamSourceElement);
+  }
+  (() => {
+    let element = document.currentScript;
+    if (!element)
+      return;
+    if (element.hasAttribute("data-turbo-suppress-warning"))
+      return;
+    element = element.parentElement;
+    while (element) {
+      if (element == document.body) {
+        return console.warn(unindent`
+        You are loading Turbo from a <script> element inside the <body> element. This is probably not what you meant to do!
+
+        Load your application’s JavaScript bundle inside the <head> element instead. <script> elements in <body> are evaluated with each page change.
+
+        For more information, see: https://turbo.hotwired.dev/handbook/building#working-with-script-elements
+
+        ——
+        Suppress this warning by adding a "data-turbo-suppress-warning" attribute to: %s
+      `, element.outerHTML);
+      }
+      element = element.parentElement;
+    }
+  })();
+  window.Turbo = Turbo;
+  start();
+
+  // node_modules/@hotwired/turbo-rails/app/javascript/turbo/cable.js
+  var consumer;
+  async function getConsumer() {
+    return consumer || setConsumer(createConsumer2().then(setConsumer));
+  }
+  function setConsumer(newConsumer) {
+    return consumer = newConsumer;
+  }
+  async function createConsumer2() {
+    const { createConsumer: createConsumer3 } = await Promise.resolve().then(() => (init_src(), src_exports));
+    return createConsumer3();
+  }
+  async function subscribeTo(channel, mixin) {
+    const { subscriptions } = await getConsumer();
+    return subscriptions.create(channel, mixin);
+  }
+
+  // node_modules/@hotwired/turbo-rails/app/javascript/turbo/snakeize.js
+  function walk(obj) {
+    if (!obj || typeof obj !== "object")
+      return obj;
+    if (obj instanceof Date || obj instanceof RegExp)
+      return obj;
+    if (Array.isArray(obj))
+      return obj.map(walk);
+    return Object.keys(obj).reduce(function(acc, key) {
+      var camel = key[0].toLowerCase() + key.slice(1).replace(/([A-Z]+)/g, function(m, x) {
+        return "_" + x.toLowerCase();
+      });
+      acc[camel] = walk(obj[key]);
+      return acc;
+    }, {});
+  }
+
+  // node_modules/@hotwired/turbo-rails/app/javascript/turbo/cable_stream_source_element.js
+  var TurboCableStreamSourceElement = class extends HTMLElement {
+    async connectedCallback() {
+      connectStreamSource(this);
+      this.subscription = await subscribeTo(this.channel, { received: this.dispatchMessageEvent.bind(this) });
+    }
+    disconnectedCallback() {
+      disconnectStreamSource(this);
+      if (this.subscription)
+        this.subscription.unsubscribe();
+    }
+    dispatchMessageEvent(data) {
+      const event = new MessageEvent("message", { data });
+      return this.dispatchEvent(event);
+    }
+    get channel() {
+      const channel = this.getAttribute("channel");
+      const signed_stream_name = this.getAttribute("signed-stream-name");
+      return { channel, signed_stream_name, ...walk({ ...this.dataset }) };
+    }
+  };
+  customElements.define("turbo-cable-stream-source", TurboCableStreamSourceElement);
+
+  // node_modules/@hotwired/turbo-rails/app/javascript/turbo/fetch_requests.js
+  function encodeMethodIntoRequestBody(event) {
+    if (event.target instanceof HTMLFormElement) {
+      const { target: form, detail: { fetchOptions } } = event;
+      form.addEventListener("turbo:submit-start", ({ detail: { formSubmission: { submitter } } }) => {
+        const method = submitter && submitter.formMethod || fetchOptions.body && fetchOptions.body.get("_method") || form.getAttribute("method");
+        if (!/get/i.test(method)) {
+          if (/post/i.test(method)) {
+            fetchOptions.body.delete("_method");
+          } else {
+            fetchOptions.body.set("_method", method);
+          }
+          fetchOptions.method = "post";
+        }
+      }, { once: true });
+    }
+  }
+
+  // node_modules/@hotwired/turbo-rails/app/javascript/turbo/index.js
+  addEventListener("turbo:before-fetch-request", encodeMethodIntoRequestBody);
+})();

--- a/app/assets/javascripts/hotwire-livereload.js
+++ b/app/assets/javascripts/hotwire-livereload.js
@@ -602,16 +602,29 @@
 
   // app/javascript/lib/hotwire-livereload-received.js
   var import_debounce = __toModule(require_debounce());
-  var hotwire_livereload_received_default = (0, import_debounce.default)(({ force_reload }) => {
+  var debounced_soft_reload = (0, import_debounce.default)(() => {
+    console.log("[Hotwire::Livereload] Files changed. Reloading..");
+    Turbo.visit(window.location.href, { action: "replace" });
+  }, 300, true);
+  var hotwire_livereload_received_default = ({ mode, changed }) => {
     const onErrorPage = document.title === "Action Controller: Exception caught";
-    if (onErrorPage || force_reload) {
+    if (onErrorPage || mode === "force") {
       console.log("[Hotwire::Livereload] Files changed. Force reloading..");
       document.location.reload();
     } else {
-      console.log("[Hotwire::Livereload] Files changed. Reloading..");
-      Turbo.visit(window.location.href, { action: "replace" });
+      if (mode === "css") {
+        changed.forEach((item, index) => {
+          const stylesheet = document.querySelector(`[data-stylesheet="${item.file}"]`);
+          if (stylesheet) {
+            console.log(`[Hotwire::Livereload] Stylesheet ${item.file} changed. Reloading..`);
+            stylesheet.href = item.path;
+          }
+        });
+      } else {
+        debounced_soft_reload();
+      }
     }
-  }, 300);
+  };
 
   // app/javascript/hotwire-livereload.js
   var consumer = (0, import_actioncable.createConsumer)();

--- a/app/assets/javascripts/hotwire-livereload.js
+++ b/app/assets/javascripts/hotwire-livereload.js
@@ -21,585 +21,6 @@
     return __reExport(__markAsModule(__defProp(module != null ? __create(__getProtoOf(module)) : {}, "default", module && module.__esModule && "default" in module ? { get: () => module.default, enumerable: true } : { value: module, enumerable: true })), module);
   };
 
-  // node_modules/@rails/actioncable/app/assets/javascripts/action_cable.js
-  var require_action_cable = __commonJS({
-    "node_modules/@rails/actioncable/app/assets/javascripts/action_cable.js"(exports, module) {
-      (function(global, factory) {
-        typeof exports === "object" && typeof module !== "undefined" ? factory(exports) : typeof define === "function" && define.amd ? define(["exports"], factory) : factory(global.ActionCable = {});
-      })(exports, function(exports2) {
-        "use strict";
-        var adapters = {
-          logger: self.console,
-          WebSocket: self.WebSocket
-        };
-        var logger = {
-          log: function log() {
-            if (this.enabled) {
-              var _adapters$logger;
-              for (var _len = arguments.length, messages = Array(_len), _key = 0; _key < _len; _key++) {
-                messages[_key] = arguments[_key];
-              }
-              messages.push(Date.now());
-              (_adapters$logger = adapters.logger).log.apply(_adapters$logger, ["[ActionCable]"].concat(messages));
-            }
-          }
-        };
-        var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function(obj) {
-          return typeof obj;
-        } : function(obj) {
-          return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-        };
-        var classCallCheck = function(instance, Constructor) {
-          if (!(instance instanceof Constructor)) {
-            throw new TypeError("Cannot call a class as a function");
-          }
-        };
-        var createClass = function() {
-          function defineProperties(target, props) {
-            for (var i = 0; i < props.length; i++) {
-              var descriptor = props[i];
-              descriptor.enumerable = descriptor.enumerable || false;
-              descriptor.configurable = true;
-              if ("value" in descriptor)
-                descriptor.writable = true;
-              Object.defineProperty(target, descriptor.key, descriptor);
-            }
-          }
-          return function(Constructor, protoProps, staticProps) {
-            if (protoProps)
-              defineProperties(Constructor.prototype, protoProps);
-            if (staticProps)
-              defineProperties(Constructor, staticProps);
-            return Constructor;
-          };
-        }();
-        var now = function now2() {
-          return new Date().getTime();
-        };
-        var secondsSince = function secondsSince2(time) {
-          return (now() - time) / 1e3;
-        };
-        var clamp = function clamp2(number, min, max) {
-          return Math.max(min, Math.min(max, number));
-        };
-        var ConnectionMonitor = function() {
-          function ConnectionMonitor2(connection) {
-            classCallCheck(this, ConnectionMonitor2);
-            this.visibilityDidChange = this.visibilityDidChange.bind(this);
-            this.connection = connection;
-            this.reconnectAttempts = 0;
-          }
-          ConnectionMonitor2.prototype.start = function start() {
-            if (!this.isRunning()) {
-              this.startedAt = now();
-              delete this.stoppedAt;
-              this.startPolling();
-              addEventListener("visibilitychange", this.visibilityDidChange);
-              logger.log("ConnectionMonitor started. pollInterval = " + this.getPollInterval() + " ms");
-            }
-          };
-          ConnectionMonitor2.prototype.stop = function stop() {
-            if (this.isRunning()) {
-              this.stoppedAt = now();
-              this.stopPolling();
-              removeEventListener("visibilitychange", this.visibilityDidChange);
-              logger.log("ConnectionMonitor stopped");
-            }
-          };
-          ConnectionMonitor2.prototype.isRunning = function isRunning() {
-            return this.startedAt && !this.stoppedAt;
-          };
-          ConnectionMonitor2.prototype.recordPing = function recordPing() {
-            this.pingedAt = now();
-          };
-          ConnectionMonitor2.prototype.recordConnect = function recordConnect() {
-            this.reconnectAttempts = 0;
-            this.recordPing();
-            delete this.disconnectedAt;
-            logger.log("ConnectionMonitor recorded connect");
-          };
-          ConnectionMonitor2.prototype.recordDisconnect = function recordDisconnect() {
-            this.disconnectedAt = now();
-            logger.log("ConnectionMonitor recorded disconnect");
-          };
-          ConnectionMonitor2.prototype.startPolling = function startPolling() {
-            this.stopPolling();
-            this.poll();
-          };
-          ConnectionMonitor2.prototype.stopPolling = function stopPolling() {
-            clearTimeout(this.pollTimeout);
-          };
-          ConnectionMonitor2.prototype.poll = function poll() {
-            var _this = this;
-            this.pollTimeout = setTimeout(function() {
-              _this.reconnectIfStale();
-              _this.poll();
-            }, this.getPollInterval());
-          };
-          ConnectionMonitor2.prototype.getPollInterval = function getPollInterval() {
-            var _constructor$pollInte = this.constructor.pollInterval, min = _constructor$pollInte.min, max = _constructor$pollInte.max, multiplier = _constructor$pollInte.multiplier;
-            var interval = multiplier * Math.log(this.reconnectAttempts + 1);
-            return Math.round(clamp(interval, min, max) * 1e3);
-          };
-          ConnectionMonitor2.prototype.reconnectIfStale = function reconnectIfStale() {
-            if (this.connectionIsStale()) {
-              logger.log("ConnectionMonitor detected stale connection. reconnectAttempts = " + this.reconnectAttempts + ", pollInterval = " + this.getPollInterval() + " ms, time disconnected = " + secondsSince(this.disconnectedAt) + " s, stale threshold = " + this.constructor.staleThreshold + " s");
-              this.reconnectAttempts++;
-              if (this.disconnectedRecently()) {
-                logger.log("ConnectionMonitor skipping reopening recent disconnect");
-              } else {
-                logger.log("ConnectionMonitor reopening");
-                this.connection.reopen();
-              }
-            }
-          };
-          ConnectionMonitor2.prototype.connectionIsStale = function connectionIsStale() {
-            return secondsSince(this.pingedAt ? this.pingedAt : this.startedAt) > this.constructor.staleThreshold;
-          };
-          ConnectionMonitor2.prototype.disconnectedRecently = function disconnectedRecently() {
-            return this.disconnectedAt && secondsSince(this.disconnectedAt) < this.constructor.staleThreshold;
-          };
-          ConnectionMonitor2.prototype.visibilityDidChange = function visibilityDidChange() {
-            var _this2 = this;
-            if (document.visibilityState === "visible") {
-              setTimeout(function() {
-                if (_this2.connectionIsStale() || !_this2.connection.isOpen()) {
-                  logger.log("ConnectionMonitor reopening stale connection on visibilitychange. visibilityState = " + document.visibilityState);
-                  _this2.connection.reopen();
-                }
-              }, 200);
-            }
-          };
-          return ConnectionMonitor2;
-        }();
-        ConnectionMonitor.pollInterval = {
-          min: 3,
-          max: 30,
-          multiplier: 5
-        };
-        ConnectionMonitor.staleThreshold = 6;
-        var INTERNAL = {
-          message_types: {
-            welcome: "welcome",
-            disconnect: "disconnect",
-            ping: "ping",
-            confirmation: "confirm_subscription",
-            rejection: "reject_subscription"
-          },
-          disconnect_reasons: {
-            unauthorized: "unauthorized",
-            invalid_request: "invalid_request",
-            server_restart: "server_restart"
-          },
-          default_mount_path: "/cable",
-          protocols: ["actioncable-v1-json", "actioncable-unsupported"]
-        };
-        var message_types = INTERNAL.message_types, protocols = INTERNAL.protocols;
-        var supportedProtocols = protocols.slice(0, protocols.length - 1);
-        var indexOf = [].indexOf;
-        var Connection = function() {
-          function Connection2(consumer2) {
-            classCallCheck(this, Connection2);
-            this.open = this.open.bind(this);
-            this.consumer = consumer2;
-            this.subscriptions = this.consumer.subscriptions;
-            this.monitor = new ConnectionMonitor(this);
-            this.disconnected = true;
-          }
-          Connection2.prototype.send = function send(data) {
-            if (this.isOpen()) {
-              this.webSocket.send(JSON.stringify(data));
-              return true;
-            } else {
-              return false;
-            }
-          };
-          Connection2.prototype.open = function open() {
-            if (this.isActive()) {
-              logger.log("Attempted to open WebSocket, but existing socket is " + this.getState());
-              return false;
-            } else {
-              logger.log("Opening WebSocket, current state is " + this.getState() + ", subprotocols: " + protocols);
-              if (this.webSocket) {
-                this.uninstallEventHandlers();
-              }
-              this.webSocket = new adapters.WebSocket(this.consumer.url, protocols);
-              this.installEventHandlers();
-              this.monitor.start();
-              return true;
-            }
-          };
-          Connection2.prototype.close = function close() {
-            var _ref = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {
-              allowReconnect: true
-            }, allowReconnect = _ref.allowReconnect;
-            if (!allowReconnect) {
-              this.monitor.stop();
-            }
-            if (this.isActive()) {
-              return this.webSocket.close();
-            }
-          };
-          Connection2.prototype.reopen = function reopen() {
-            logger.log("Reopening WebSocket, current state is " + this.getState());
-            if (this.isActive()) {
-              try {
-                return this.close();
-              } catch (error) {
-                logger.log("Failed to reopen WebSocket", error);
-              } finally {
-                logger.log("Reopening WebSocket in " + this.constructor.reopenDelay + "ms");
-                setTimeout(this.open, this.constructor.reopenDelay);
-              }
-            } else {
-              return this.open();
-            }
-          };
-          Connection2.prototype.getProtocol = function getProtocol() {
-            if (this.webSocket) {
-              return this.webSocket.protocol;
-            }
-          };
-          Connection2.prototype.isOpen = function isOpen() {
-            return this.isState("open");
-          };
-          Connection2.prototype.isActive = function isActive() {
-            return this.isState("open", "connecting");
-          };
-          Connection2.prototype.isProtocolSupported = function isProtocolSupported() {
-            return indexOf.call(supportedProtocols, this.getProtocol()) >= 0;
-          };
-          Connection2.prototype.isState = function isState() {
-            for (var _len = arguments.length, states = Array(_len), _key = 0; _key < _len; _key++) {
-              states[_key] = arguments[_key];
-            }
-            return indexOf.call(states, this.getState()) >= 0;
-          };
-          Connection2.prototype.getState = function getState() {
-            if (this.webSocket) {
-              for (var state in adapters.WebSocket) {
-                if (adapters.WebSocket[state] === this.webSocket.readyState) {
-                  return state.toLowerCase();
-                }
-              }
-            }
-            return null;
-          };
-          Connection2.prototype.installEventHandlers = function installEventHandlers() {
-            for (var eventName in this.events) {
-              var handler = this.events[eventName].bind(this);
-              this.webSocket["on" + eventName] = handler;
-            }
-          };
-          Connection2.prototype.uninstallEventHandlers = function uninstallEventHandlers() {
-            for (var eventName in this.events) {
-              this.webSocket["on" + eventName] = function() {
-              };
-            }
-          };
-          return Connection2;
-        }();
-        Connection.reopenDelay = 500;
-        Connection.prototype.events = {
-          message: function message(event) {
-            if (!this.isProtocolSupported()) {
-              return;
-            }
-            var _JSON$parse = JSON.parse(event.data), identifier = _JSON$parse.identifier, message2 = _JSON$parse.message, reason = _JSON$parse.reason, reconnect = _JSON$parse.reconnect, type = _JSON$parse.type;
-            switch (type) {
-              case message_types.welcome:
-                this.monitor.recordConnect();
-                return this.subscriptions.reload();
-              case message_types.disconnect:
-                logger.log("Disconnecting. Reason: " + reason);
-                return this.close({
-                  allowReconnect: reconnect
-                });
-              case message_types.ping:
-                return this.monitor.recordPing();
-              case message_types.confirmation:
-                this.subscriptions.confirmSubscription(identifier);
-                return this.subscriptions.notify(identifier, "connected");
-              case message_types.rejection:
-                return this.subscriptions.reject(identifier);
-              default:
-                return this.subscriptions.notify(identifier, "received", message2);
-            }
-          },
-          open: function open() {
-            logger.log("WebSocket onopen event, using '" + this.getProtocol() + "' subprotocol");
-            this.disconnected = false;
-            if (!this.isProtocolSupported()) {
-              logger.log("Protocol is unsupported. Stopping monitor and disconnecting.");
-              return this.close({
-                allowReconnect: false
-              });
-            }
-          },
-          close: function close(event) {
-            logger.log("WebSocket onclose event");
-            if (this.disconnected) {
-              return;
-            }
-            this.disconnected = true;
-            this.monitor.recordDisconnect();
-            return this.subscriptions.notifyAll("disconnected", {
-              willAttemptReconnect: this.monitor.isRunning()
-            });
-          },
-          error: function error() {
-            logger.log("WebSocket onerror event");
-          }
-        };
-        var extend = function extend2(object, properties) {
-          if (properties != null) {
-            for (var key in properties) {
-              var value = properties[key];
-              object[key] = value;
-            }
-          }
-          return object;
-        };
-        var Subscription = function() {
-          function Subscription2(consumer2) {
-            var params = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
-            var mixin = arguments[2];
-            classCallCheck(this, Subscription2);
-            this.consumer = consumer2;
-            this.identifier = JSON.stringify(params);
-            extend(this, mixin);
-          }
-          Subscription2.prototype.perform = function perform(action) {
-            var data = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
-            data.action = action;
-            return this.send(data);
-          };
-          Subscription2.prototype.send = function send(data) {
-            return this.consumer.send({
-              command: "message",
-              identifier: this.identifier,
-              data: JSON.stringify(data)
-            });
-          };
-          Subscription2.prototype.unsubscribe = function unsubscribe() {
-            return this.consumer.subscriptions.remove(this);
-          };
-          return Subscription2;
-        }();
-        var SubscriptionGuarantor = function() {
-          function SubscriptionGuarantor2(subscriptions) {
-            classCallCheck(this, SubscriptionGuarantor2);
-            this.subscriptions = subscriptions;
-            this.pendingSubscriptions = [];
-          }
-          SubscriptionGuarantor2.prototype.guarantee = function guarantee(subscription) {
-            if (this.pendingSubscriptions.indexOf(subscription) == -1) {
-              logger.log("SubscriptionGuarantor guaranteeing " + subscription.identifier);
-              this.pendingSubscriptions.push(subscription);
-            } else {
-              logger.log("SubscriptionGuarantor already guaranteeing " + subscription.identifier);
-            }
-            this.startGuaranteeing();
-          };
-          SubscriptionGuarantor2.prototype.forget = function forget(subscription) {
-            logger.log("SubscriptionGuarantor forgetting " + subscription.identifier);
-            this.pendingSubscriptions = this.pendingSubscriptions.filter(function(s) {
-              return s !== subscription;
-            });
-          };
-          SubscriptionGuarantor2.prototype.startGuaranteeing = function startGuaranteeing() {
-            this.stopGuaranteeing();
-            this.retrySubscribing();
-          };
-          SubscriptionGuarantor2.prototype.stopGuaranteeing = function stopGuaranteeing() {
-            clearTimeout(this.retryTimeout);
-          };
-          SubscriptionGuarantor2.prototype.retrySubscribing = function retrySubscribing() {
-            var _this = this;
-            this.retryTimeout = setTimeout(function() {
-              if (_this.subscriptions && typeof _this.subscriptions.subscribe === "function") {
-                _this.pendingSubscriptions.map(function(subscription) {
-                  logger.log("SubscriptionGuarantor resubscribing " + subscription.identifier);
-                  _this.subscriptions.subscribe(subscription);
-                });
-              }
-            }, 500);
-          };
-          return SubscriptionGuarantor2;
-        }();
-        var Subscriptions = function() {
-          function Subscriptions2(consumer2) {
-            classCallCheck(this, Subscriptions2);
-            this.consumer = consumer2;
-            this.guarantor = new SubscriptionGuarantor(this);
-            this.subscriptions = [];
-          }
-          Subscriptions2.prototype.create = function create(channelName, mixin) {
-            var channel = channelName;
-            var params = (typeof channel === "undefined" ? "undefined" : _typeof(channel)) === "object" ? channel : {
-              channel
-            };
-            var subscription = new Subscription(this.consumer, params, mixin);
-            return this.add(subscription);
-          };
-          Subscriptions2.prototype.add = function add(subscription) {
-            this.subscriptions.push(subscription);
-            this.consumer.ensureActiveConnection();
-            this.notify(subscription, "initialized");
-            this.subscribe(subscription);
-            return subscription;
-          };
-          Subscriptions2.prototype.remove = function remove(subscription) {
-            this.forget(subscription);
-            if (!this.findAll(subscription.identifier).length) {
-              this.sendCommand(subscription, "unsubscribe");
-            }
-            return subscription;
-          };
-          Subscriptions2.prototype.reject = function reject(identifier) {
-            var _this = this;
-            return this.findAll(identifier).map(function(subscription) {
-              _this.forget(subscription);
-              _this.notify(subscription, "rejected");
-              return subscription;
-            });
-          };
-          Subscriptions2.prototype.forget = function forget(subscription) {
-            this.guarantor.forget(subscription);
-            this.subscriptions = this.subscriptions.filter(function(s) {
-              return s !== subscription;
-            });
-            return subscription;
-          };
-          Subscriptions2.prototype.findAll = function findAll(identifier) {
-            return this.subscriptions.filter(function(s) {
-              return s.identifier === identifier;
-            });
-          };
-          Subscriptions2.prototype.reload = function reload() {
-            var _this2 = this;
-            return this.subscriptions.map(function(subscription) {
-              return _this2.subscribe(subscription);
-            });
-          };
-          Subscriptions2.prototype.notifyAll = function notifyAll(callbackName) {
-            var _this3 = this;
-            for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-              args[_key - 1] = arguments[_key];
-            }
-            return this.subscriptions.map(function(subscription) {
-              return _this3.notify.apply(_this3, [subscription, callbackName].concat(args));
-            });
-          };
-          Subscriptions2.prototype.notify = function notify(subscription, callbackName) {
-            for (var _len2 = arguments.length, args = Array(_len2 > 2 ? _len2 - 2 : 0), _key2 = 2; _key2 < _len2; _key2++) {
-              args[_key2 - 2] = arguments[_key2];
-            }
-            var subscriptions = void 0;
-            if (typeof subscription === "string") {
-              subscriptions = this.findAll(subscription);
-            } else {
-              subscriptions = [subscription];
-            }
-            return subscriptions.map(function(subscription2) {
-              return typeof subscription2[callbackName] === "function" ? subscription2[callbackName].apply(subscription2, args) : void 0;
-            });
-          };
-          Subscriptions2.prototype.subscribe = function subscribe(subscription) {
-            if (this.sendCommand(subscription, "subscribe")) {
-              this.guarantor.guarantee(subscription);
-            }
-          };
-          Subscriptions2.prototype.confirmSubscription = function confirmSubscription(identifier) {
-            var _this4 = this;
-            logger.log("Subscription confirmed " + identifier);
-            this.findAll(identifier).map(function(subscription) {
-              return _this4.guarantor.forget(subscription);
-            });
-          };
-          Subscriptions2.prototype.sendCommand = function sendCommand(subscription, command) {
-            var identifier = subscription.identifier;
-            return this.consumer.send({
-              command,
-              identifier
-            });
-          };
-          return Subscriptions2;
-        }();
-        var Consumer = function() {
-          function Consumer2(url) {
-            classCallCheck(this, Consumer2);
-            this._url = url;
-            this.subscriptions = new Subscriptions(this);
-            this.connection = new Connection(this);
-          }
-          Consumer2.prototype.send = function send(data) {
-            return this.connection.send(data);
-          };
-          Consumer2.prototype.connect = function connect() {
-            return this.connection.open();
-          };
-          Consumer2.prototype.disconnect = function disconnect() {
-            return this.connection.close({
-              allowReconnect: false
-            });
-          };
-          Consumer2.prototype.ensureActiveConnection = function ensureActiveConnection() {
-            if (!this.connection.isActive()) {
-              return this.connection.open();
-            }
-          };
-          createClass(Consumer2, [{
-            key: "url",
-            get: function get$$1() {
-              return createWebSocketURL(this._url);
-            }
-          }]);
-          return Consumer2;
-        }();
-        function createWebSocketURL(url) {
-          if (typeof url === "function") {
-            url = url();
-          }
-          if (url && !/^wss?:/i.test(url)) {
-            var a = document.createElement("a");
-            a.href = url;
-            a.href = a.href;
-            a.protocol = a.protocol.replace("http", "ws");
-            return a.href;
-          } else {
-            return url;
-          }
-        }
-        function createConsumer2() {
-          var url = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : getConfig("url") || INTERNAL.default_mount_path;
-          return new Consumer(url);
-        }
-        function getConfig(name) {
-          var element = document.head.querySelector("meta[name='action-cable-" + name + "']");
-          if (element) {
-            return element.getAttribute("content");
-          }
-        }
-        exports2.Connection = Connection;
-        exports2.ConnectionMonitor = ConnectionMonitor;
-        exports2.Consumer = Consumer;
-        exports2.INTERNAL = INTERNAL;
-        exports2.Subscription = Subscription;
-        exports2.Subscriptions = Subscriptions;
-        exports2.SubscriptionGuarantor = SubscriptionGuarantor;
-        exports2.adapters = adapters;
-        exports2.createWebSocketURL = createWebSocketURL;
-        exports2.logger = logger;
-        exports2.createConsumer = createConsumer2;
-        exports2.getConfig = getConfig;
-        Object.defineProperty(exports2, "__esModule", {
-          value: true
-        });
-      });
-    }
-  });
-
   // node_modules/debounce/index.js
   var require_debounce = __commonJS({
     "node_modules/debounce/index.js"(exports, module) {
@@ -654,8 +75,492 @@
     }
   });
 
-  // app/javascript/hotwire-livereload.js
-  var import_actioncable = __toModule(require_action_cable());
+  // node_modules/@rails/actioncable/app/assets/javascripts/actioncable.esm.js
+  var adapters = {
+    logger: typeof console !== "undefined" ? console : void 0,
+    WebSocket: typeof WebSocket !== "undefined" ? WebSocket : void 0
+  };
+  var logger = {
+    log(...messages) {
+      if (this.enabled) {
+        messages.push(Date.now());
+        adapters.logger.log("[ActionCable]", ...messages);
+      }
+    }
+  };
+  var now = () => new Date().getTime();
+  var secondsSince = (time) => (now() - time) / 1e3;
+  var ConnectionMonitor = class {
+    constructor(connection) {
+      this.visibilityDidChange = this.visibilityDidChange.bind(this);
+      this.connection = connection;
+      this.reconnectAttempts = 0;
+    }
+    start() {
+      if (!this.isRunning()) {
+        this.startedAt = now();
+        delete this.stoppedAt;
+        this.startPolling();
+        addEventListener("visibilitychange", this.visibilityDidChange);
+        logger.log(`ConnectionMonitor started. stale threshold = ${this.constructor.staleThreshold} s`);
+      }
+    }
+    stop() {
+      if (this.isRunning()) {
+        this.stoppedAt = now();
+        this.stopPolling();
+        removeEventListener("visibilitychange", this.visibilityDidChange);
+        logger.log("ConnectionMonitor stopped");
+      }
+    }
+    isRunning() {
+      return this.startedAt && !this.stoppedAt;
+    }
+    recordPing() {
+      this.pingedAt = now();
+    }
+    recordConnect() {
+      this.reconnectAttempts = 0;
+      this.recordPing();
+      delete this.disconnectedAt;
+      logger.log("ConnectionMonitor recorded connect");
+    }
+    recordDisconnect() {
+      this.disconnectedAt = now();
+      logger.log("ConnectionMonitor recorded disconnect");
+    }
+    startPolling() {
+      this.stopPolling();
+      this.poll();
+    }
+    stopPolling() {
+      clearTimeout(this.pollTimeout);
+    }
+    poll() {
+      this.pollTimeout = setTimeout(() => {
+        this.reconnectIfStale();
+        this.poll();
+      }, this.getPollInterval());
+    }
+    getPollInterval() {
+      const { staleThreshold, reconnectionBackoffRate } = this.constructor;
+      const backoff = Math.pow(1 + reconnectionBackoffRate, Math.min(this.reconnectAttempts, 10));
+      const jitterMax = this.reconnectAttempts === 0 ? 1 : reconnectionBackoffRate;
+      const jitter = jitterMax * Math.random();
+      return staleThreshold * 1e3 * backoff * (1 + jitter);
+    }
+    reconnectIfStale() {
+      if (this.connectionIsStale()) {
+        logger.log(`ConnectionMonitor detected stale connection. reconnectAttempts = ${this.reconnectAttempts}, time stale = ${secondsSince(this.refreshedAt)} s, stale threshold = ${this.constructor.staleThreshold} s`);
+        this.reconnectAttempts++;
+        if (this.disconnectedRecently()) {
+          logger.log(`ConnectionMonitor skipping reopening recent disconnect. time disconnected = ${secondsSince(this.disconnectedAt)} s`);
+        } else {
+          logger.log("ConnectionMonitor reopening");
+          this.connection.reopen();
+        }
+      }
+    }
+    get refreshedAt() {
+      return this.pingedAt ? this.pingedAt : this.startedAt;
+    }
+    connectionIsStale() {
+      return secondsSince(this.refreshedAt) > this.constructor.staleThreshold;
+    }
+    disconnectedRecently() {
+      return this.disconnectedAt && secondsSince(this.disconnectedAt) < this.constructor.staleThreshold;
+    }
+    visibilityDidChange() {
+      if (document.visibilityState === "visible") {
+        setTimeout(() => {
+          if (this.connectionIsStale() || !this.connection.isOpen()) {
+            logger.log(`ConnectionMonitor reopening stale connection on visibilitychange. visibilityState = ${document.visibilityState}`);
+            this.connection.reopen();
+          }
+        }, 200);
+      }
+    }
+  };
+  ConnectionMonitor.staleThreshold = 6;
+  ConnectionMonitor.reconnectionBackoffRate = 0.15;
+  var INTERNAL = {
+    message_types: {
+      welcome: "welcome",
+      disconnect: "disconnect",
+      ping: "ping",
+      confirmation: "confirm_subscription",
+      rejection: "reject_subscription"
+    },
+    disconnect_reasons: {
+      unauthorized: "unauthorized",
+      invalid_request: "invalid_request",
+      server_restart: "server_restart",
+      remote: "remote"
+    },
+    default_mount_path: "/cable",
+    protocols: ["actioncable-v1-json", "actioncable-unsupported"]
+  };
+  var { message_types, protocols } = INTERNAL;
+  var supportedProtocols = protocols.slice(0, protocols.length - 1);
+  var indexOf = [].indexOf;
+  var Connection = class {
+    constructor(consumer2) {
+      this.open = this.open.bind(this);
+      this.consumer = consumer2;
+      this.subscriptions = this.consumer.subscriptions;
+      this.monitor = new ConnectionMonitor(this);
+      this.disconnected = true;
+    }
+    send(data) {
+      if (this.isOpen()) {
+        this.webSocket.send(JSON.stringify(data));
+        return true;
+      } else {
+        return false;
+      }
+    }
+    open() {
+      if (this.isActive()) {
+        logger.log(`Attempted to open WebSocket, but existing socket is ${this.getState()}`);
+        return false;
+      } else {
+        const socketProtocols = [...protocols, ...this.consumer.subprotocols || []];
+        logger.log(`Opening WebSocket, current state is ${this.getState()}, subprotocols: ${socketProtocols}`);
+        if (this.webSocket) {
+          this.uninstallEventHandlers();
+        }
+        this.webSocket = new adapters.WebSocket(this.consumer.url, socketProtocols);
+        this.installEventHandlers();
+        this.monitor.start();
+        return true;
+      }
+    }
+    close({ allowReconnect } = {
+      allowReconnect: true
+    }) {
+      if (!allowReconnect) {
+        this.monitor.stop();
+      }
+      if (this.isOpen()) {
+        return this.webSocket.close();
+      }
+    }
+    reopen() {
+      logger.log(`Reopening WebSocket, current state is ${this.getState()}`);
+      if (this.isActive()) {
+        try {
+          return this.close();
+        } catch (error) {
+          logger.log("Failed to reopen WebSocket", error);
+        } finally {
+          logger.log(`Reopening WebSocket in ${this.constructor.reopenDelay}ms`);
+          setTimeout(this.open, this.constructor.reopenDelay);
+        }
+      } else {
+        return this.open();
+      }
+    }
+    getProtocol() {
+      if (this.webSocket) {
+        return this.webSocket.protocol;
+      }
+    }
+    isOpen() {
+      return this.isState("open");
+    }
+    isActive() {
+      return this.isState("open", "connecting");
+    }
+    triedToReconnect() {
+      return this.monitor.reconnectAttempts > 0;
+    }
+    isProtocolSupported() {
+      return indexOf.call(supportedProtocols, this.getProtocol()) >= 0;
+    }
+    isState(...states) {
+      return indexOf.call(states, this.getState()) >= 0;
+    }
+    getState() {
+      if (this.webSocket) {
+        for (let state in adapters.WebSocket) {
+          if (adapters.WebSocket[state] === this.webSocket.readyState) {
+            return state.toLowerCase();
+          }
+        }
+      }
+      return null;
+    }
+    installEventHandlers() {
+      for (let eventName in this.events) {
+        const handler = this.events[eventName].bind(this);
+        this.webSocket[`on${eventName}`] = handler;
+      }
+    }
+    uninstallEventHandlers() {
+      for (let eventName in this.events) {
+        this.webSocket[`on${eventName}`] = function() {
+        };
+      }
+    }
+  };
+  Connection.reopenDelay = 500;
+  Connection.prototype.events = {
+    message(event) {
+      if (!this.isProtocolSupported()) {
+        return;
+      }
+      const { identifier, message, reason, reconnect, type } = JSON.parse(event.data);
+      switch (type) {
+        case message_types.welcome:
+          if (this.triedToReconnect()) {
+            this.reconnectAttempted = true;
+          }
+          this.monitor.recordConnect();
+          return this.subscriptions.reload();
+        case message_types.disconnect:
+          logger.log(`Disconnecting. Reason: ${reason}`);
+          return this.close({
+            allowReconnect: reconnect
+          });
+        case message_types.ping:
+          return this.monitor.recordPing();
+        case message_types.confirmation:
+          this.subscriptions.confirmSubscription(identifier);
+          if (this.reconnectAttempted) {
+            this.reconnectAttempted = false;
+            return this.subscriptions.notify(identifier, "connected", {
+              reconnected: true
+            });
+          } else {
+            return this.subscriptions.notify(identifier, "connected", {
+              reconnected: false
+            });
+          }
+        case message_types.rejection:
+          return this.subscriptions.reject(identifier);
+        default:
+          return this.subscriptions.notify(identifier, "received", message);
+      }
+    },
+    open() {
+      logger.log(`WebSocket onopen event, using '${this.getProtocol()}' subprotocol`);
+      this.disconnected = false;
+      if (!this.isProtocolSupported()) {
+        logger.log("Protocol is unsupported. Stopping monitor and disconnecting.");
+        return this.close({
+          allowReconnect: false
+        });
+      }
+    },
+    close(event) {
+      logger.log("WebSocket onclose event");
+      if (this.disconnected) {
+        return;
+      }
+      this.disconnected = true;
+      this.monitor.recordDisconnect();
+      return this.subscriptions.notifyAll("disconnected", {
+        willAttemptReconnect: this.monitor.isRunning()
+      });
+    },
+    error() {
+      logger.log("WebSocket onerror event");
+    }
+  };
+  var extend = function(object, properties) {
+    if (properties != null) {
+      for (let key in properties) {
+        const value = properties[key];
+        object[key] = value;
+      }
+    }
+    return object;
+  };
+  var Subscription = class {
+    constructor(consumer2, params = {}, mixin) {
+      this.consumer = consumer2;
+      this.identifier = JSON.stringify(params);
+      extend(this, mixin);
+    }
+    perform(action, data = {}) {
+      data.action = action;
+      return this.send(data);
+    }
+    send(data) {
+      return this.consumer.send({
+        command: "message",
+        identifier: this.identifier,
+        data: JSON.stringify(data)
+      });
+    }
+    unsubscribe() {
+      return this.consumer.subscriptions.remove(this);
+    }
+  };
+  var SubscriptionGuarantor = class {
+    constructor(subscriptions) {
+      this.subscriptions = subscriptions;
+      this.pendingSubscriptions = [];
+    }
+    guarantee(subscription) {
+      if (this.pendingSubscriptions.indexOf(subscription) == -1) {
+        logger.log(`SubscriptionGuarantor guaranteeing ${subscription.identifier}`);
+        this.pendingSubscriptions.push(subscription);
+      } else {
+        logger.log(`SubscriptionGuarantor already guaranteeing ${subscription.identifier}`);
+      }
+      this.startGuaranteeing();
+    }
+    forget(subscription) {
+      logger.log(`SubscriptionGuarantor forgetting ${subscription.identifier}`);
+      this.pendingSubscriptions = this.pendingSubscriptions.filter((s) => s !== subscription);
+    }
+    startGuaranteeing() {
+      this.stopGuaranteeing();
+      this.retrySubscribing();
+    }
+    stopGuaranteeing() {
+      clearTimeout(this.retryTimeout);
+    }
+    retrySubscribing() {
+      this.retryTimeout = setTimeout(() => {
+        if (this.subscriptions && typeof this.subscriptions.subscribe === "function") {
+          this.pendingSubscriptions.map((subscription) => {
+            logger.log(`SubscriptionGuarantor resubscribing ${subscription.identifier}`);
+            this.subscriptions.subscribe(subscription);
+          });
+        }
+      }, 500);
+    }
+  };
+  var Subscriptions = class {
+    constructor(consumer2) {
+      this.consumer = consumer2;
+      this.guarantor = new SubscriptionGuarantor(this);
+      this.subscriptions = [];
+    }
+    create(channelName, mixin) {
+      const channel = channelName;
+      const params = typeof channel === "object" ? channel : {
+        channel
+      };
+      const subscription = new Subscription(this.consumer, params, mixin);
+      return this.add(subscription);
+    }
+    add(subscription) {
+      this.subscriptions.push(subscription);
+      this.consumer.ensureActiveConnection();
+      this.notify(subscription, "initialized");
+      this.subscribe(subscription);
+      return subscription;
+    }
+    remove(subscription) {
+      this.forget(subscription);
+      if (!this.findAll(subscription.identifier).length) {
+        this.sendCommand(subscription, "unsubscribe");
+      }
+      return subscription;
+    }
+    reject(identifier) {
+      return this.findAll(identifier).map((subscription) => {
+        this.forget(subscription);
+        this.notify(subscription, "rejected");
+        return subscription;
+      });
+    }
+    forget(subscription) {
+      this.guarantor.forget(subscription);
+      this.subscriptions = this.subscriptions.filter((s) => s !== subscription);
+      return subscription;
+    }
+    findAll(identifier) {
+      return this.subscriptions.filter((s) => s.identifier === identifier);
+    }
+    reload() {
+      return this.subscriptions.map((subscription) => this.subscribe(subscription));
+    }
+    notifyAll(callbackName, ...args) {
+      return this.subscriptions.map((subscription) => this.notify(subscription, callbackName, ...args));
+    }
+    notify(subscription, callbackName, ...args) {
+      let subscriptions;
+      if (typeof subscription === "string") {
+        subscriptions = this.findAll(subscription);
+      } else {
+        subscriptions = [subscription];
+      }
+      return subscriptions.map((subscription2) => typeof subscription2[callbackName] === "function" ? subscription2[callbackName](...args) : void 0);
+    }
+    subscribe(subscription) {
+      if (this.sendCommand(subscription, "subscribe")) {
+        this.guarantor.guarantee(subscription);
+      }
+    }
+    confirmSubscription(identifier) {
+      logger.log(`Subscription confirmed ${identifier}`);
+      this.findAll(identifier).map((subscription) => this.guarantor.forget(subscription));
+    }
+    sendCommand(subscription, command) {
+      const { identifier } = subscription;
+      return this.consumer.send({
+        command,
+        identifier
+      });
+    }
+  };
+  var Consumer = class {
+    constructor(url) {
+      this._url = url;
+      this.subscriptions = new Subscriptions(this);
+      this.connection = new Connection(this);
+      this.subprotocols = [];
+    }
+    get url() {
+      return createWebSocketURL(this._url);
+    }
+    send(data) {
+      return this.connection.send(data);
+    }
+    connect() {
+      return this.connection.open();
+    }
+    disconnect() {
+      return this.connection.close({
+        allowReconnect: false
+      });
+    }
+    ensureActiveConnection() {
+      if (!this.connection.isActive()) {
+        return this.connection.open();
+      }
+    }
+    addSubProtocol(subprotocol) {
+      this.subprotocols = [...this.subprotocols, subprotocol];
+    }
+  };
+  function createWebSocketURL(url) {
+    if (typeof url === "function") {
+      url = url();
+    }
+    if (url && !/^wss?:/i.test(url)) {
+      const a = document.createElement("a");
+      a.href = url;
+      a.href = a.href;
+      a.protocol = a.protocol.replace("http", "ws");
+      return a.href;
+    } else {
+      return url;
+    }
+  }
+  function createConsumer(url = getConfig("url") || INTERNAL.default_mount_path) {
+    return new Consumer(url);
+  }
+  function getConfig(name) {
+    const element = document.head.querySelector(`meta[name='action-cable-${name}']`);
+    if (element) {
+      return element.getAttribute("content");
+    }
+  }
 
   // app/javascript/lib/hotwire-livereload-received.js
   var import_debounce = __toModule(require_debounce());
@@ -689,7 +594,21 @@
   };
 
   // app/javascript/hotwire-livereload.js
-  var consumer = (0, import_actioncable.createConsumer)();
+  var consumer = createConsumer();
+  consumer.connection.close = function({ allowReconnect } = {
+    allowReconnect: true
+  }) {
+    if (!allowReconnect) {
+      this.monitor.stop();
+    }
+    if (this.isOpen()) {
+      this.webSocket.close();
+    }
+    if (allowReconnect) {
+      console.log("[Hotwire::Livereload] Websocket reconnecting");
+      return this.open();
+    }
+  };
   consumer.subscriptions.create("Hotwire::Livereload::ReloadChannel", {
     received: hotwire_livereload_received_default,
     connected() {

--- a/app/javascript/hotwire-livereload-turbo-stream.js
+++ b/app/javascript/hotwire-livereload-turbo-stream.js
@@ -6,7 +6,7 @@ import received from "./lib/hotwire-livereload-received"
   window.HotwireLivereload = function({ target }) {
     const element = target.querySelector('template')?.content.getElementById('hotwire-livereload')
     if (element) {
-      received({ force_reload: element.dataset.forceReload })
+      received({ changed: JSON.parse(element.dataset.changed), mode: element.dataset.mode })
     }
   };
 

--- a/app/javascript/hotwire-livereload-turbo.js
+++ b/app/javascript/hotwire-livereload-turbo.js
@@ -1,0 +1,1 @@
+import "@hotwired/turbo-rails";

--- a/app/javascript/hotwire-livereload.js
+++ b/app/javascript/hotwire-livereload.js
@@ -2,6 +2,22 @@ import { createConsumer } from "@rails/actioncable"
 import received from "./lib/hotwire-livereload-received"
 
 const consumer = createConsumer()
+
+consumer.connection.close = function ({allowReconnect: allowReconnect} = {
+    allowReconnect: true
+}) {
+    if (!allowReconnect) {
+        this.monitor.stop();
+    }
+    if (this.isOpen()) {
+        this.webSocket.close();
+    }
+    if (allowReconnect) {
+        console.log("[Hotwire::Livereload] Websocket reconnecting");
+        return this.open();
+    }
+};
+
 consumer.subscriptions.create("Hotwire::Livereload::ReloadChannel", {
   received,
 

--- a/app/javascript/lib/hotwire-livereload-received.js
+++ b/app/javascript/lib/hotwire-livereload-received.js
@@ -1,13 +1,27 @@
 import debounce from "debounce"
 
-export default debounce(({force_reload}) => {
+const debounced_soft_reload = debounce(() => {
+  console.log("[Hotwire::Livereload] Files changed. Reloading..")
+  Turbo.visit(window.location.href, {action: 'replace'})
+}, 300, true)
+
+export default ({mode, changed}) => {
   const onErrorPage = document.title === "Action Controller: Exception caught"
 
-  if (onErrorPage || force_reload) {
+  if (onErrorPage || mode === "force") {
     console.log("[Hotwire::Livereload] Files changed. Force reloading..")
     document.location.reload()
   } else {
-    console.log("[Hotwire::Livereload] Files changed. Reloading..")
-    Turbo.visit(window.location.href, { action: 'replace' })
+    if (mode === "css"){
+      changed.forEach((item, index) => {
+        const stylesheet = document.querySelector(`[data-stylesheet="${item.file}"]`);
+        if(stylesheet) {
+          console.log(`[Hotwire::Livereload] Stylesheet ${item.file} changed. Reloading..`)
+          stylesheet.href = item.path;
+        }
+      })
+    } else {
+      debounced_soft_reload()
+    }
   }
-}, 300)
+}

--- a/app/javascript/lib/hotwire-livereload-received.js
+++ b/app/javascript/lib/hotwire-livereload-received.js
@@ -21,7 +21,12 @@ export default ({mode, changed}) => {
         }
       })
     } else {
-      debounced_soft_reload()
+      if (window.Turbo) {
+        debounced_soft_reload()
+      } else {
+        console.log("[Hotwire::Livereload] Files changed. Force reloading..")
+        document.location.reload()
+      }
     }
   }
 }

--- a/app/views/hotwire/livereload/_turbo_stream.html.erb
+++ b/app/views/hotwire/livereload/_turbo_stream.html.erb
@@ -1,4 +1,4 @@
 <%= tag.div(id: 'hotwire-livereload', data: {
   changed: changed.to_json,
-  force_reload: force_reload || nil
+  mode: mode
 }) %>

--- a/lib/hotwire/livereload.rb
+++ b/lib/hotwire/livereload.rb
@@ -1,7 +1,19 @@
 require "hotwire/livereload/engine"
+require "hotwire/livereload/middleware"
 
-module Hotwire
-  module Livereload
-    DISABLE_FILE = "tmp/livereload-disabled.txt"
+if defined?(::Rails::Railtie)
+  module Hotwire
+    module Livereload
+      DISABLE_FILE = "tmp/livereload-disabled.txt"
+
+      class Railtie < ::Rails::Railtie
+        initializer("rollbar.user_informer") do |app|
+          app.config.middleware.insert_before(
+            ActionDispatch::ShowExceptions,
+            Hotwire::Livereload::Middleware
+          )
+        end
+      end
+    end
   end
 end

--- a/lib/hotwire/livereload/middleware.rb
+++ b/lib/hotwire/livereload/middleware.rb
@@ -8,7 +8,7 @@ module Hotwire
       def call(env)
         status, headers, body = @app.call(env)
         request = ActionDispatch::Request.new(env)
-        if status > 0 && ![200, 301, 302].include?(status) && request.method == "GET"
+        if status.to_i > 0 && ![200, 301, 302].include?(status) && request.method == "GET"
           replacement_text = Hotwire::Livereload.error_page_injected_code.call
           body = replace_placeholder(replacement_text, body, headers) if replacement_text
         end

--- a/lib/hotwire/livereload/middleware.rb
+++ b/lib/hotwire/livereload/middleware.rb
@@ -1,0 +1,35 @@
+module Hotwire
+  module Livereload
+    class Middleware
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        status, headers, body = @app.call(env)
+        request = ActionDispatch::Request.new(env)
+        if status > 0 && ![200, 301, 302].include?(status) && request.method == "GET"
+          replacement_text = Hotwire::Livereload.error_page_injected_code.call
+          body = replace_placeholder(replacement_text, body, headers) if replacement_text
+        end
+
+        [status, headers, body]
+      end
+
+      private
+
+      # - body interface is .each so we cannot use anything else
+      # - always call .close on the old body so it can get garbage collected if it is a File
+      def replace_placeholder(replacement_text, body, headers)
+        new_body = []
+        body.each do |chunk|
+          new_body << chunk.gsub(/(<\/head>)/, replacement_text + "\\1")
+        end
+        headers["Content-Length"] = new_body.inject(0) { |sum, x| sum + x.bytesize }.to_s
+        new_body
+      ensure
+        body.close if body&.respond_to?(:close)
+      end
+    end
+  end
+end

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,27 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@hotwired/turbo": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.2.0.tgz",
+      "integrity": "sha512-CYr6N9NfqsjhmZx1xVQ8zYcDo4hTm7sTUpJydbNgMRyG+YfF/9ADIQQ2TtcBdkl2zi/12a3OTWX0UMzNZnAK9w=="
+    },
+    "@hotwired/turbo-rails": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo-rails/-/turbo-rails-7.2.0.tgz",
+      "integrity": "sha512-RxJJGINeLa2lyI078LLSbqZDI7RarxTDMVlgKnsLvtFEn8Pa7ySEcDUxHp5YiLXGbLacAIH/dcfD0JfCWe5Dqw==",
+      "requires": {
+        "@hotwired/turbo": "^7.2.0",
+        "@rails/actioncable": "^7.0"
+      },
+      "dependencies": {
+        "@rails/actioncable": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.0.4.tgz",
+          "integrity": "sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ=="
+        }
+      }
+    },
     "@rails/actioncable": {
       "version": "6.1.4-1",
       "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-6.1.4-1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,52 @@
 {
   "name": "hotwire-livereload",
+  "lockfileVersion": 2,
   "requires": true,
-  "lockfileVersion": 1,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@hotwired/turbo-rails": "^7.2.0",
+        "@rails/actioncable": "^7.1.3",
+        "debounce": "^1.2.1",
+        "esbuild": "^0.12.25"
+      }
+    },
+    "node_modules/@hotwired/turbo": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.2.0.tgz",
+      "integrity": "sha512-CYr6N9NfqsjhmZx1xVQ8zYcDo4hTm7sTUpJydbNgMRyG+YfF/9ADIQQ2TtcBdkl2zi/12a3OTWX0UMzNZnAK9w==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@hotwired/turbo-rails": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo-rails/-/turbo-rails-7.2.0.tgz",
+      "integrity": "sha512-RxJJGINeLa2lyI078LLSbqZDI7RarxTDMVlgKnsLvtFEn8Pa7ySEcDUxHp5YiLXGbLacAIH/dcfD0JfCWe5Dqw==",
+      "dependencies": {
+        "@hotwired/turbo": "^7.2.0",
+        "@rails/actioncable": "^7.0"
+      }
+    },
+    "node_modules/@rails/actioncable": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.1.3.tgz",
+      "integrity": "sha512-ojNvnoZtPN0pYvVFtlO7dyEN9Oml1B6IDM+whGKVak69MMYW99lC2NOWXWeE3bmwEydbP/nn6ERcpfjHVjYQjA=="
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
+    },
+    "node_modules/esbuild": {
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz",
+      "integrity": "sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    }
+  },
   "dependencies": {
     "@hotwired/turbo": {
       "version": "7.2.0",
@@ -15,19 +60,12 @@
       "requires": {
         "@hotwired/turbo": "^7.2.0",
         "@rails/actioncable": "^7.0"
-      },
-      "dependencies": {
-        "@rails/actioncable": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.0.4.tgz",
-          "integrity": "sha512-tz4oM+Zn9CYsvtyicsa/AwzKZKL+ITHWkhiu7x+xF77clh2b4Rm+s6xnOgY/sGDWoFWZmtKsE95hxBPkgQQNnQ=="
-        }
       }
     },
     "@rails/actioncable": {
-      "version": "6.1.4-1",
-      "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-6.1.4-1.tgz",
-      "integrity": "sha512-b6sLoMop3gX22Wm2P5LPpKcZGwsf1ZoAGS+g1HrTrdlsZ/ENOKIBiSNnHOJajHwcYlF0TefBs7e7jIYZHVYihQ=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@rails/actioncable/-/actioncable-7.1.3.tgz",
+      "integrity": "sha512-ojNvnoZtPN0pYvVFtlO7dyEN9Oml1B6IDM+whGKVak69MMYW99lC2NOWXWeE3bmwEydbP/nn6ERcpfjHVjYQjA=="
     },
     "debounce": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@hotwired/turbo-rails": "^7.2.0",
-    "@rails/actioncable": "^6.1.4-1",
+    "@rails/actioncable": "^7.1.3",
     "debounce": "^1.2.1",
     "esbuild": "^0.12.25"
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "watch": "npm run build -- --watch"
   },
   "dependencies": {
+    "@hotwired/turbo-rails": "^7.2.0",
     "@rails/actioncable": "^6.1.4-1",
     "debounce": "^1.2.1",
     "esbuild": "^0.12.25"


### PR DESCRIPTION
This PR introduce 2 major changes:
1. 3 different reload modes (css, soft, hard)
2. Auto-reload on error pages.

Reload modes:
Depending on what changed we can do different reload types.
1. When css files are changed we can inject new CSS into current page. This is especially cool when you do some actions on page (open dropdown, collapses, some ajax request etc), which will be reset after a page reload. This requires external css build tools like dart-sass, which will automatically rebuild css files.
2. When non-js files are changed we can do fast reload using Turbo.visit()
3. When js files are changed we must do a full page reload. If we do Turbolinks.visit(), it will detect that js files are changed and do a full reload anyway, but this will result in double page load.

Auto-reload on error pages: I have added a middleware which injects livereload code into error pages. 

To be honest, i did this couple of month ago and did not have time to submit a PR, and now looking at the code it looks like an alien wrote it. But if you think i need to improve something in this PR, i'll try to do this. 