### PR TITLE
Add support for jsbundling-rails and cssbundling-rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Folders listened by default:
 - `app/components`
 - `config/locales`
 
+The gem detects if you use [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) or [`cssbundling-rails`](https://github.com/rails/cssbundling-rails) and watches for changes in their output folder `app/assets/builds` automatically.
+
 ## Configuration
 
 You can watch for changes in additional folders by adding them to `listen_paths`:

--- a/lib/hotwire/livereload/engine.rb
+++ b/lib/hotwire/livereload/engine.rb
@@ -41,8 +41,19 @@ module Hotwire
             app/assets/images
             app/components
             config/locales
-          ].map { |p| Rails.root.join(p) }
-          options.listen_paths += default_listen_paths.select { |p| Dir.exist?(p) }
+          ]
+          if defined?(Jsbundling)
+            default_listen_paths -= %w[app/javascript]
+            default_listen_paths += %w[app/assets/builds]
+          end
+          if defined?(Cssbundling)
+            default_listen_paths -= %w[app/assets/stylesheets]
+            default_listen_paths += %w[app/assets/builds]
+          end
+          options.listen_paths += default_listen_paths
+            .uniq
+            .map { |p| Rails.root.join(p) }
+            .select { |p| Dir.exist?(p) }
         end
       end
 


### PR DESCRIPTION
Watching for `app/assets/builds` automatically when `jsbundling-rails` or `cssbundling-rails` are used.