### PR TITLE
Add nonce to javascipt tag to support strict content security policies

### DIFF
--- a/app/views/hotwire/livereload/_head_action_cable.html.erb
+++ b/app/views/hotwire/livereload/_head_action_cable.html.erb
@@ -1,3 +1,3 @@
 <% if Rails.env.development? %>
-  <%= javascript_include_tag('hotwire-livereload', defer: true) %>
+  <%= javascript_include_tag('hotwire-livereload', defer: true, nonce: true) %>
 <% end %>

--- a/app/views/hotwire/livereload/_head_turbo_stream.html.erb
+++ b/app/views/hotwire/livereload/_head_turbo_stream.html.erb
@@ -1,4 +1,4 @@
 <% if Rails.env.development? %>
   <%= turbo_stream_from('hotwire-livereload') %>
-  <%= javascript_include_tag('hotwire-livereload-turbo-stream', defer: true) %>
+  <%= javascript_include_tag('hotwire-livereload-turbo-stream', defer: true, nonce: true) %>
 <% end %>


### PR DESCRIPTION
In our project we are using a strict content security policy (CSP). This includes a `script-src` with `nonce`. 

Therefore all scripts include inside a page need to use this nonce on their tag.

Rails has build in support for this, but it needs to be used. 

This pull request adds `nonce: true` to `javascript_include_tag` . If no CSP is configure this does not have any effect. 