### PR TITLE
Depend on railties and not on rails gem

### DIFF
--- a/hotwire-livereload.gemspec
+++ b/hotwire-livereload.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", ">= 6.0.0"
+  spec.add_dependency "railties", ">= 6.0.0"
+  spec.add_dependency "actioncable", ">= 6.0.0"
   spec.add_dependency "listen", ">= 3.0.0"
 end


### PR DESCRIPTION
Hello,
in my Rails application, I don't use the whole Rails default stack - For example I don't need to use any ActionText or ActionMailbox gem. 

Unfortunately, depending on`rails` gem enforces non-needed gem with this gem. This gem for working depends on a small fraction of Rails stack and can work only three `railties`, `actioncable` and `listen` gems. It's better to require only these gem as necessary dependencies.

I created a similar PR (https://github.com/rails/jsbundling-rails/pull/13) to this issue in `jsbundling-rails` two years ago (accepted).

E.g. `tailwindcss-rails` or `cssbundling-rails` depends on `railties` gem as well
- https://github.com/rails/tailwindcss-rails/blob/main/tailwindcss-rails.gemspec#L21
- https://github.com/rails/cssbundling-rails/blob/main/cssbundling-rails.gemspec#L14