### PR TITLE
Add ability to skip default listen paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Rails.application.configure do
 end
 ```
 
+When you use Tailwind, it will also listen for changes in views/helpers/javascript, and then generate new CSS file in `app/assets/builds` folder. This can cause multiple reloads and the scroll position will be lost. To avoid that, you can skip listening to the folders that are used by Tailwind:
+```ruby
+  # ...
+  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/helpers")
+  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/javascript")
+  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/views")
+```
+
 Instead of a direct ActionCable websocket connection, you can reuse the existing TurboStream websocket connection and send updates using standard turbo-streams:
 ```ruby
 # config/environments/development.rb

--- a/README.md
+++ b/README.md
@@ -79,14 +79,6 @@ Rails.application.configure do
 end
 ```
 
-When you use Tailwind, it will also listen for changes in views/helpers/javascript, and then generate new CSS file in `app/assets/builds` folder. This can cause multiple reloads and the scroll position will be lost. To avoid that, you can skip listening to the folders that are used by Tailwind:
-```ruby
-  # ...
-  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/helpers")
-  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/javascript")
-  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/views")
-```
-
 Instead of a direct ActionCable websocket connection, you can reuse the existing TurboStream websocket connection and send updates using standard turbo-streams:
 ```ruby
 # config/environments/development.rb

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Rails.application.configure do
 end
 ```
 
+You can skip one or few default listen paths:
+```ruby
+# config/environments/development.rb
+
+Rails.application.configure do
+  # ...
+  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/views")
+end
+```
+
 You can disable default listen paths and fully override them:
 ```ruby
 # config/environments/development.rb

--- a/lib/hotwire/livereload/engine.rb
+++ b/lib/hotwire/livereload/engine.rb
@@ -8,6 +8,7 @@ module Hotwire
       isolate_namespace Hotwire::Livereload
       config.hotwire_livereload = ActiveSupport::OrderedOptions.new
       config.hotwire_livereload.listen_paths ||= []
+      config.hotwire_livereload.skip_listen_paths ||= []
       config.hotwire_livereload.force_reload_paths ||= []
       config.hotwire_livereload.reload_method = :action_cable
       config.hotwire_livereload.disable_default_listeners = false
@@ -30,6 +31,7 @@ module Hotwire
 
       initializer "hotwire_livereload.set_configs" do |app|
         options = app.config.hotwire_livereload
+        skip_listen_paths = options.skip_listen_paths.map(&:to_s).uniq
 
         unless options.disable_default_listeners
           default_listen_paths = %w[
@@ -54,6 +56,7 @@ module Hotwire
             .uniq
             .map { |p| Rails.root.join(p) }
             .select { |p| Dir.exist?(p) }
+            .reject { |p| skip_listen_paths.include?(p.to_s) }
         end
       end
 


### PR DESCRIPTION
Instead of disabling and fully overriding default paths, it's now possible to skip one of few of them instead:

```ruby
# config/environments/development.rb

Rails.application.configure do
  # ...
  config.hotwire_livereload.skip_listen_paths << Rails.root.join("app/views")
end
```