### PR TITLE
Clear turbo cache before visiting to avoid unwanted snapshot restoration

### DIFF
--- a/app/assets/javascripts/hotwire-livereload-turbo-stream.js
+++ b/app/assets/javascripts/hotwire-livereload-turbo-stream.js
@@ -115,6 +115,7 @@
     } else {
       console.log("[Hotwire::Livereload] Files changed. Reloading..");
       hotwire_livereload_scroll_position_default.save();
+      Turbo.cache.clear();
       Turbo.visit(window.location.href, { action: "replace" });
     }
   }, 300);

--- a/app/assets/javascripts/hotwire-livereload.js
+++ b/app/assets/javascripts/hotwire-livereload.js
@@ -697,6 +697,7 @@
     } else {
       console.log("[Hotwire::Livereload] Files changed. Reloading..");
       hotwire_livereload_scroll_position_default.save();
+      Turbo.cache.clear();
       Turbo.visit(window.location.href, { action: "replace" });
     }
   }, 300);

--- a/app/javascript/lib/hotwire-livereload-received.js
+++ b/app/javascript/lib/hotwire-livereload-received.js
@@ -10,6 +10,7 @@ export default debounce(({force_reload}) => {
   } else {
     console.log("[Hotwire::Livereload] Files changed. Reloading..")
     scrollPosition.save()
+    Turbo.cache.clear()
     Turbo.visit(window.location.href, { action: 'replace' })
   }
 }, 300)


### PR DESCRIPTION
I realised that when working on some elements of a webpage that are below the fold, the first livereload would perform perfectly, but for the subsequent ones, the page would jump to the top before restoring the scroll, which is unexpected and very unsettling.

I tracked it down to the turbo cache, turbo is trying to show the snapshot for the current page while the request is performing, but it does not make sense as we will restore scroll just after.

I see 2 possible solutions : 

- Try to restore the scroll earlier, just after the snapshot is loaded, and make sure it stays at the right value after the new document is shown
- Clear the cache before visiting, so no snapshot is restored

This PR implements solution #2, I believe as we are trying to reload the page after a change on the code, having a snapshot of the page makes no sense.