### PR TITLE
Allow options pass through for Listen.to call

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ In that case you need to place `hotwire_livereload_tags` helper in your layout *
 
 By default, Listen uses a more efficient mechanism called "native" which relies on the operating system's file system events to detect changes. However, in some cases, such as when working with network-mounted file systems or in certain virtualized environments, the native mechanism may not work reliably. In such cases, enabling force_polling ensures that file changes are still detected, albeit with a slightly higher resource usage.
 
-You may use listen_to_options to pass these options like:
+You may use listen_options to pass these options like:
 ```ruby
 # config/environments/development.rb
 
 Rails.application.configure do
   # ...
-  config.hotwire_livereload.listen_to_options[:force_polling] = true
+  config.hotwire_livereload.listen_options[:force_polling] = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,20 @@ In that case you need to place `hotwire_livereload_tags` helper in your layout *
 </head>
 ```
 
+[Listen gem](https://github.com/guard/listen), which is used for file system monitoring, accepts [options](https://github.com/guard/listen?tab=readme-ov-file#options) like enabling a fallback mechanism called "polling" to detect file changes.
+
+By default, Listen uses a more efficient mechanism called "native" which relies on the operating system's file system events to detect changes. However, in some cases, such as when working with network-mounted file systems or in certain virtualized environments, the native mechanism may not work reliably. In such cases, enabling force_polling ensures that file changes are still detected, albeit with a slightly higher resource usage.
+
+You may use listen_to_options to pass these options like:
+```ruby
+# config/environments/development.rb
+
+Rails.application.configure do
+  # ...
+  config.hotwire_livereload.listen_to_options[:force_polling] = true
+end
+```
+
 ## Disable livereload
 
 To temporarily disable livereload use:

--- a/lib/hotwire/livereload/engine.rb
+++ b/lib/hotwire/livereload/engine.rb
@@ -15,6 +15,7 @@ module Hotwire
         #{root}/app/channels
         #{root}/app/helpers
       ]
+      config.hotwire_livereload.listen_to_options ||= {}
 
       initializer "hotwire_livereload.assets" do
         if Rails.application.config.respond_to?(:assets)
@@ -63,7 +64,7 @@ module Hotwire
           listen_paths = options.listen_paths.map(&:to_s).uniq
           force_reload_paths = options.force_reload_paths.map(&:to_s).uniq.join("|")
 
-          @listener = Listen.to(*listen_paths) do |modified, added, removed|
+          @listener = Listen.to(*listen_paths, **config.hotwire_livereload.listen_to_options) do |modified, added, removed|
             unless File.exist?(DISABLE_FILE)
               changed = [modified, removed, added].flatten.uniq
               next unless changed.any?

--- a/lib/hotwire/livereload/engine.rb
+++ b/lib/hotwire/livereload/engine.rb
@@ -15,7 +15,7 @@ module Hotwire
         #{root}/app/channels
         #{root}/app/helpers
       ]
-      config.hotwire_livereload.listen_to_options ||= {}
+      config.hotwire_livereload.listen_options ||= {}
 
       initializer "hotwire_livereload.assets" do
         if Rails.application.config.respond_to?(:assets)
@@ -64,7 +64,7 @@ module Hotwire
           listen_paths = options.listen_paths.map(&:to_s).uniq
           force_reload_paths = options.force_reload_paths.map(&:to_s).uniq.join("|")
 
-          @listener = Listen.to(*listen_paths, **config.hotwire_livereload.listen_to_options) do |modified, added, removed|
+          @listener = Listen.to(*listen_paths, **config.hotwire_livereload.listen_options) do |modified, added, removed|
             unless File.exist?(DISABLE_FILE)
               changed = [modified, removed, added].flatten.uniq
               next unless changed.any?


### PR DESCRIPTION
Hi, first of all thanks for this gem! I really like the way it piggybacks the modern rails features.

Now that we don't get too romantic here, I did head into some troubles. Not per se because of the gem itself but as we all know the rabbit hole can sometimes go pretty deep when planet align just perfectly.

# Issue
Problem is that when running on virtualized environment that is using some not-so-inotify-friendly partition systems, the default mechanisms for detecting changes might fail altogether, and silently. There are multiple hoops that might end up causing this, but  in my case it's this specific Windows computer that I'm developing on from time to time. 

# Environment
My problematic environment is:

Windows -> WSL -> Docker (docker compose + volumes mounted from Windows disks) -> Alpine Linux running RoR

# Listen the silence
Now, the awesome guard gem listen (respect to ppl behind that too!) tries to handle problematic situations gracefully but might need a bit more help to function proper.

In the docs of listen gem, they nicely suggest to use wdm gem if you're on windows, but as it is obvious from my actual environment above, wdm gem does not really help in this case as my running environment is linux, but the underlying filesystem is actually NTFS so wdm did not scratch the itch.

# What
So, I did a little stab at the code to enable passing options that Listen.to takes to be able to force the polling mechanism (and meanwhile at it, just pass through other options as well if given).
