### PR TITLE
Add debounce to server side listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run installer:
 rails livereload:install
 ```
 
-Folders listened by default:
+Folders watched by default:
 - `app/views`
 - `app/helpers`
 - `app/javascript`
@@ -31,6 +31,12 @@ Folders listened by default:
 - `config/locales`
 
 The gem detects if you use [`jsbundling-rails`](https://github.com/rails/jsbundling-rails) or [`cssbundling-rails`](https://github.com/rails/cssbundling-rails) and watches for changes in their output folder `app/assets/builds` automatically.
+
+In your layout, make sure you don't `turbo-track` your JS/CSS in development:
+```diff
++ <%= stylesheet_link_tag "application", "data-turbo-track": Rails.env.production? ? "reload" : "" %>
+- <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ Rails.application.configure do
 end
 ```
 
+### Listen debounce delay
+
+If your app uses TailwindCSS or similar that compiles your CSS from looking at your templates, you can end up in a situation, where updating a template triggers twice for changes; once for the template and once for the rebuilt CSS. This can lead to unreliable reloads, ie. the reload happening before the CSS is built.
+
+To avoid this, you can add a debounce delay to the file watcher:
+
+```ruby
+# config/environments/development.rb
+
+Rails.application.configure do
+  # ...
+  config.hotwire_livereload.debounce_delay_ms = 300 # in milliseconds
+end
+```
+
 ## Disable livereload
 
 To temporarily disable livereload use:

--- a/lib/hotwire/livereload/engine.rb
+++ b/lib/hotwire/livereload/engine.rb
@@ -119,7 +119,7 @@ module Hotwire
 
     def self.debounce(wait_ms, &block)
       if wait_ms.zero?
-        return -> (*args) { yield(*args) }
+        return ->(*args) { yield(*args) }
       end
 
       mutex = Mutex.new

--- a/lib/hotwire/livereload/engine.rb
+++ b/lib/hotwire/livereload/engine.rb
@@ -16,6 +16,7 @@ module Hotwire
         #{root}/app/helpers
       ]
       config.hotwire_livereload.listen_options ||= {}
+      config.hotwire_livereload.debounce_delay_ms = 0
 
       initializer "hotwire_livereload.assets" do
         if Rails.application.config.respond_to?(:assets)
@@ -60,6 +61,14 @@ module Hotwire
 
       config.after_initialize do |app|
         if Rails.env.development? && Hotwire::Livereload.server_process?
+          @trigger_reload = (Hotwire::Livereload.debounce(config.hotwire_livereload.debounce_delay_ms) do |options|
+            if config.hotwire_livereload.reload_method == :turbo_stream
+              Hotwire::Livereload.turbo_stream(options)
+            else
+              Hotwire::Livereload.action_cable(options)
+            end
+          end)
+
           options = app.config.hotwire_livereload
           listen_paths = options.listen_paths.map(&:to_s).uniq
           force_reload_paths = options.force_reload_paths.map(&:to_s).uniq.join("|")
@@ -74,11 +83,7 @@ module Hotwire
               end
 
               options = {changed: changed, force_reload: force_reload}
-              if config.hotwire_livereload.reload_method == :turbo_stream
-                Hotwire::Livereload.turbo_stream(options)
-              else
-                Hotwire::Livereload.action_cable(options)
-              end
+              @trigger_reload.call(options)
             end
           end
           @listener.start
@@ -110,6 +115,28 @@ module Hotwire
       rails_server = defined?(Rails::Server)
 
       puma_process || rails_server
+    end
+
+    def self.debounce(wait_ms, &block)
+      if wait_ms.zero?
+        return -> (*args) { yield(*args) }
+      end
+
+      mutex = Mutex.new
+      timer_thread = nil
+      seconds = wait_ms.to_f / 1000.0
+
+      lambda do |*args|
+        mutex.synchronize do
+          # Cancel previous timer
+          timer_thread&.kill
+
+          timer_thread = Thread.new do
+            sleep(seconds)
+            yield(*args)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Annoyed by [this](https://github.com/kirillplatonov/hotwire-livereload/pull/52#issuecomment-1888117218) again, it suddenly hit me that the debounce could just be on the server side instead.

This will fix the problem of a template update triggering twice when TailwindCSS: once for the template file and once for the updated CSS. This would lead to unreliable reloads.

I opted to disable it as default, as it does add a slight delay to all updates. Definitely worth it if you use Tailwind though!

**Also** included a note to the README about not `data-turbo-track`ing assets in dev. Same, with Tailwind, any template change would trigger a CSS rebuild and because of `data-turbo-track` it would lead to a complete refresh of the page, breaking scroll restoration.

This also seems to be the issue in #56