### PR TITLE
Dropped Redis dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ Automatically reload Hotwire Turbo when app files are modified.
 
 https://user-images.githubusercontent.com/839922/148676469-0acfa036-832e-4b40-aa05-1fdd945baa1f.mp4
 
-## Dependencies
-
-* [Redis](https://redis.io/)
-
 ## Getting started
 
 Add `hotwire-livereload` to your Gemfile:

--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -12,19 +12,3 @@ else
   say %(  Add <%= hotwire_livereload_tags %> within the <head> tag in your custom layout.)
   say %(  If using `config.hotwire_livereload.reload_method = :turbo_stream`, place *after* the `<%= action_cable_meta_tag %>`.)
 end
-
-if CABLE_CONFIG_PATH.exist?
-  gemfile = File.read(Rails.root.join("Gemfile"))
-  if gemfile.include?("redis")
-    say "Uncomment redis in Gemfile"
-    uncomment_lines "Gemfile", %r{gem ['"]redis['"]}
-  else
-    say "Add redis to Gemfile"
-    gem "redis"
-  end
-
-  say "Switch development cable to use redis"
-  gsub_file CABLE_CONFIG_PATH.to_s, /development:\n\s+adapter: async/, "development:\n  adapter: redis\n  url: redis://localhost:6379/1"
-else
-  say 'ActionCable config file (config/cable.yml) is missing. Uncomment "gem \'redis\'" in your Gemfile and create config/cable.yml to use Hotwire Livereload.'
-end


### PR DESCRIPTION
Starting from Rails 7.0 live reloading works fine with default `async` ActiveCable adapter. It will continue to work with both `redis` and `solid-cable` too if the host app uses them in development.

Closes #64